### PR TITLE
Allow HTTP integrations to return a json downlink payload

### DIFF
--- a/src/channels/router_http_channel.erl
+++ b/src/channels/router_http_channel.erl
@@ -102,6 +102,7 @@ handle_http_res(Res, Channel, Data) ->
                 frame_up => maps:get(sequence, Data)},
     Result1 = case Res of
                   {ok, StatusCode, _ResponseHeaders, ResponseBody} when StatusCode >= 200, StatusCode =< 300 ->
+                      router_device_worker:handle_downlink(ResponseBody, Channel),
                       maps:merge(Result0, #{status => success, description => ResponseBody});
                   {ok, StatusCode, _ResponseHeaders, ResponseBody} ->
                       maps:merge(Result0, #{status => failure, 

--- a/src/channels/router_mqtt_channel.erl
+++ b/src/channels/router_mqtt_channel.erl
@@ -76,21 +76,8 @@ handle_call(_Msg, State) ->
     lager:warning("rcvd unknown call msg: ~p", [_Msg]),
     {ok, ok, State}.
 
-handle_info({publish, #{payload := Payload0}=Map}, #state{channel=Channel}=State) ->
-    try jsx:decode(Payload0, [return_maps]) of
-        JSON ->
-            case maps:find(<<"payload_raw">>, JSON) of
-                {ok, Payload1} ->
-                    DeviceWorkerPid = router_channel:device_worker(Channel),
-                    Msg = {false, 1, base64:decode(Payload1)},
-                    router_device_worker:queue_message(DeviceWorkerPid, Msg);
-                error ->
-                    lager:warning("JSON downlink did not contain raw_payload field: ~p", [JSON])
-            end
-    catch
-        _:_ ->
-            lager:warning("could not parse json downlink message ~p", [Map])
-    end,
+handle_info({publish, #{payload := Payload0}}, #state{channel=Channel}=State) ->
+    router_device_worker:handle_downlink(Payload0, Channel),
     {ok, State};
 handle_info(ping, #state{connection=Connection}=State) ->
     (catch emqtt:ping(Connection)),

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -125,7 +125,7 @@ http_test(Config) ->
     WorkerID = router_devices_sup:id(<<"yolo_id">>),
     {ok, Device0} = router_device:get(DB, CF, WorkerID),
     %% Send CONFIRMED_UP frame packet needing an ack back
-    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), 0)},
+    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 0)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName),
@@ -161,7 +161,7 @@ http_test(Config) ->
     ?assertEqual([Msg], router_device:queue(Device1)),
 
     %% Sending UNCONFIRMED_UP frame packet and then we should get back message that was in queue
-    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), 1)},
+    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 1)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName),
@@ -197,6 +197,44 @@ http_test(Config) ->
 
     {ok, Device2} = router_device:get(DB, CF, WorkerID),
     ?assertEqual([], router_device:queue(Device2)),
+
+    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 2, #{body => <<1:8/integer, "reply">>})},
+    test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
+                                   <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
+                                   <<"hotspot_name">> => erlang:list_to_binary(HotspotName),
+                                   <<"id">> => <<"yolo_id">>,
+                                   <<"name">> => <<"yolo_name">>,
+                                   <<"payload">> => base64:encode(<<"reply">>),
+                                   <<"port">> => 1,
+                                   <<"rssi">> => 0.0,
+                                   <<"sequence">> => 2,
+                                   <<"snr">> => 0.0,
+                                   <<"spreading">> => <<"SF8BW125">>,
+                                   <<"timestamp">> => 0}),
+    test_utils:wait_report_device_status(#{<<"status">> => <<"success">>,
+                                           <<"description">> => '_',
+                                           <<"reported_at">> => fun erlang:is_integer/1,
+                                           <<"category">> => <<"down">>,
+                                           <<"frame_up">> => 1,
+                                           <<"frame_down">> => 2,
+                                           <<"hotspot_name">> => erlang:list_to_binary(HotspotName)}),
+    test_utils:wait_report_channel_status(#{<<"status">> => <<"success">>,
+                                            <<"description">> => '_',
+                                            <<"reported_at">> => fun erlang:is_integer/1,
+                                            <<"category">> => <<"up">>,
+                                            <<"frame_up">> => 2,
+                                            <<"frame_down">> => 2,
+                                            <<"hotspot_name">> => erlang:list_to_binary(HotspotName),
+                                            <<"rssi">> => 0.0,
+                                            <<"snr">> => 0.0,
+                                            <<"payload_size">> => 5,
+                                            <<"payload">> => base64:encode(<<"reply">>),
+                                            <<"channel_name">> => <<"fake_http">>}),
+
+    %ok = wait_for_post_channel(PubKeyBin, base64:encode(<<"reply">>)),
+    %ok = wait_for_report_status(PubKeyBin),
+    %% Message shoud come in fast as it is already in the queue no neeed to wait
+    {ok, _Reply1} = test_utils:wait_state_channel_message({true, 1, <<"ack">>}, Device0, <<"ack">>, ?CONFIRMED_DOWN, 0, 0, 1, 2),
 
     libp2p_swarm:stop(Swarm),
     ok.
@@ -245,11 +283,11 @@ dupes_test(Config) ->
     router_device_worker:queue_message(WorkerPid, Msg1),
 
     %% Send 2 similar packet to make it look like it's coming from 2 diff hotspot
-    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin1, router_device:nwk_s_key(Device0), 0)},
+    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin1, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 0)},
     #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
     PubKeyBin2 = libp2p_crypto:pubkey_to_bin(PubKey),
     {ok, HotspotName2} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(PubKeyBin2)),
-    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), 0)},
+    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 0)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName1),
@@ -319,7 +357,7 @@ dupes_test(Config) ->
             ok
     end,
 
-    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), 1)},
+    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 1)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName2),
@@ -357,7 +395,7 @@ dupes_test(Config) ->
 
     %% check we get the second downlink again because we didn't ACK it
     %% also ack the ADR adjustments
-    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), 2, #{fopts => [{link_adr_ans, 1, 1, 1}]})},
+    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 2, #{fopts => [{link_adr_ans, 1, 1, 1}]})},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName2),
@@ -394,7 +432,7 @@ dupes_test(Config) ->
     false = lists:keymember(link_adr_req, 1, Reply3#frame.fopts),
 
     %% ack the packet, we don't expect a reply here
-    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), 2, #{should_ack => true})},
+    Stream ! {send, frame_packet(?UNCONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 2, #{should_ack => true})},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName2),
@@ -428,7 +466,7 @@ dupes_test(Config) ->
     end,
 
     %% send a confimed up to provoke a 'bare ack'
-    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), 3)},
+    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin2, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 3)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName2),
@@ -601,7 +639,7 @@ mqtt_test(Config) ->
     {ok, Device0} = router_device:get(DB, CF, WorkerID),
 
     %% Send CONFIRMED_UP frame packet needing an ack back
-    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), 0)},
+    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 0)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName),
@@ -631,7 +669,7 @@ mqtt_test(Config) ->
     %% Simulating the MQTT broker sending down a packet to transfer to device
     Payload = jsx:encode(#{<<"payload_raw">> => base64:encode(<<"mqttpayload">>)}),
     MQQTTWorkerPid ! {publish, #{payload => Payload}},
-    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), 1)},
+    Stream ! {send, frame_packet(?CONFIRMED_UP, PubKeyBin, router_device:nwk_s_key(Device0), router_device:app_s_key(Device0), 1)},
     test_utils:wait_channel_data(#{<<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
                                    <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
                                    <<"hotspot_name">> => erlang:list_to_binary(HotspotName),
@@ -720,10 +758,10 @@ join_packet(PubKeyBin, AppKey, DevNonce, RSSI) ->
     Msg = #blockchain_state_channel_message_v1_pb{msg={packet, Packet}},
     blockchain_state_channel_v1_pb:encode_msg(Msg).
 
-frame_packet(MType, PubKeyBin, SessionKey, FCnt) ->
-    frame_packet(MType, PubKeyBin, SessionKey, FCnt, #{}).
+frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt) ->
+    frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, #{}).
 
-frame_packet(MType, PubKeyBin, SessionKey, FCnt, Options) ->
+frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, Options) ->
     MHDRRFU = 0,
     Major = 0,
     <<OUI:32/integer-unsigned-big, _DID:32/integer-unsigned-big>> = ?APPEUI,
@@ -737,11 +775,12 @@ frame_packet(MType, PubKeyBin, SessionKey, FCnt, Options) ->
     RFU = 0,
     FOptsBin = lorawan_mac_commands:encode_fupopts(maps:get(fopts, Options, [])),
     FOptsLen = byte_size(FOptsBin),
-    Body = maps:get(body, Options, <<1:8>>),
+    <<Port:8/integer, Body/binary>> = maps:get(body, Options, <<1:8>>),
+    Data = lorawan_utils:reverse(lorawan_utils:cipher(Body, AppSessionKey, MType band 1, lorawan_utils:reverse(DevAddr), FCnt)),
     Payload0 = <<MType:3, MHDRRFU:3, Major:2, DevAddr:4/binary, ADR:1, ADRACKReq:1, ACK:1, RFU:1,
-                 FOptsLen:4, FCnt:16/little-unsigned-integer, FOptsBin:FOptsLen/binary, Body/binary>>,
+                 FOptsLen:4, FCnt:16/little-unsigned-integer, FOptsBin:FOptsLen/binary, Port:8/integer, Data/binary>>,
     B0 = b0(MType band 1, lorawan_utils:reverse(DevAddr), FCnt, erlang:byte_size(Payload0)),
-    MIC = crypto:cmac(aes_cbc128, SessionKey, <<B0/binary, Payload0/binary>>, 4),
+    MIC = crypto:cmac(aes_cbc128, NwkSessionKey, <<B0/binary, Payload0/binary>>, 4),
     Payload1 = <<Payload0/binary, MIC:4/binary>>,
     HeliumPacket = #packet_pb{
                       type=lorawan,

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -82,7 +82,7 @@ wait_report_channel_status(Expected) ->
                     ct:fail("wait_report_channel_status data failed ~p", [Reason])
             end
     after 250 ->
-              ct:fail("wait_report_channel_status timeout")
+            ct:fail("wait_report_channel_status timeout")
     end.
 
 wait_channel_data(Expected) ->
@@ -97,7 +97,7 @@ wait_channel_data(Expected) ->
                     ct:fail("wait_channel_data failed ~p", [Reason])
             end
     after 250 ->
-              ct:fail("wait_channel_data timeout")
+            ct:fail("wait_channel_data timeout")
     end.
 
 wait_state_channel_message(Timeout) ->
@@ -117,7 +117,7 @@ wait_state_channel_message(Timeout, PubkeyBin) ->
                     ct:fail("wait_state_channel_message failed to decode ~p ~p", [Data, {_E, _R}])
             end
     after Timeout ->
-              ct:fail("wait_state_channel_message timeout")
+            ct:fail("wait_state_channel_message timeout")
     end.
 
 wait_state_channel_message(Msg, Device, FrameData, Type, FPending, Ack, Fport, FCnt) ->


### PR DESCRIPTION
Additionally, add port and confirmed fields to json downlink payloads
for both MQTT and HTTP