### PR TITLE
Consider previously done scs when initing new scs

### DIFF
--- a/src/router_sc_worker.erl
+++ b/src/router_sc_worker.erl
@@ -156,17 +156,15 @@ init_state_channels(#state{oui=OUI, chain=Chain}) ->
     {ok, _, SigFun, _} = blockchain_swarm:keys(),
     Ledger = blockchain:ledger(Chain),
     Nonce = get_nonce(PubkeyBin, Ledger),
-    {ok, ChainHeight} = blockchain:height(Chain),
-    ok = create_and_send_sc_open_txn(PubkeyBin, SigFun, Nonce + 1, OUI, ChainHeight + ?EXPIRATION),
-    ok = create_and_send_sc_open_txn(PubkeyBin, SigFun, Nonce + 2, OUI, ChainHeight + ?EXPIRATION * 2).
+    ok = create_and_send_sc_open_txn(PubkeyBin, SigFun, Nonce + 1, OUI, ?EXPIRATION),
+    ok = create_and_send_sc_open_txn(PubkeyBin, SigFun, Nonce + 2, OUI, ?EXPIRATION * 2).
 
 -spec open_next_state_channel(State :: state(), Ledger :: blockchain_ledger_v1:ledger()) -> ok.
-open_next_state_channel(#state{oui=OUI, chain=Chain}, Ledger) ->
+open_next_state_channel(#state{oui=OUI}, Ledger) ->
     PubkeyBin = blockchain_swarm:pubkey_bin(),
     {ok, _, SigFun, _} = blockchain_swarm:keys(),
     Nonce = get_nonce(PubkeyBin, Ledger),
-    {ok, ChainHeight} = blockchain:height(Chain),
-    create_and_send_sc_open_txn(PubkeyBin, SigFun, Nonce + 1, OUI, ChainHeight + 2 * ?EXPIRATION).
+    create_and_send_sc_open_txn(PubkeyBin, SigFun, Nonce + 1, OUI, 2 * ?EXPIRATION).
 
 -spec create_and_send_sc_open_txn(PubkeyBin :: libp2p_crypto:pubkey_bin(),
                                   SigFun :: libp2p_crypto:sig_fun(),


### PR DESCRIPTION
If the router goes down (for whatever reason) but has had previously opened state channels, the current behavior always assumes that the first nonce would be equal to 1. That's an incorrect assumption. This should fix that by looking at the existing max nonce in the ledger and opening new state channels accordingly.