### PR TITLE
Avoid decoder crashes and report them

### DIFF
--- a/src/decoders/router_decoder.erl
+++ b/src/decoders/router_decoder.erl
@@ -53,6 +53,15 @@ delete(ID) ->
 
 -spec decode(binary(), binary(), integer()) -> {ok, any()} | {error, any()}.
 decode(ID, Payload, Port) ->
+    try decode_(ID, Payload, Port) of
+        Return -> Return
+    catch _Class:_Reason:_Stacktrace ->
+            lager:error("decoder ~p crashed: ~p (~p) stacktrace ~p~n", [{ID, _Reason, Payload, _Stacktrace}]),
+            {error, decoder_crashed}
+    end.
+
+-spec decode_(binary(), binary(), integer()) -> {ok, any()} | {error, any()}.
+decode_(ID, Payload, Port) ->
     case lookup(ID) of
         {error, not_found} ->
             {error, unknown_decoder};


### PR DESCRIPTION
@Vagabond This is a quick one, user had a bad JS I am guessing which caused their integration to crash