### PR TITLE
Add battery percent, and fix decoder for config status for tabs

### DIFF
--- a/src/decoders/router_decoder_browan_object_locator.erl
+++ b/src/decoders/router_decoder_browan_object_locator.erl
@@ -4,16 +4,16 @@
 
 -spec decode(router_decoder:decoder(), binary(), integer()) -> {ok, binary()} | {error, any()}.
 decode(_Decoder, << 0:1/integer, 0:1/integer, 0:1/integer, GNSError:1/integer, GNSFix:1/integer, _:1/integer, Moving:1/integer, Button:1/integer,
-                    _:4/integer, Battery:4/unsigned-integer,
+                    BatteryPercent:4/unsigned-integer, Battery:4/unsigned-integer,
                     _:1/integer, Temp:7/unsigned-integer,
                     Lat:32/integer-signed-little,
                     TempLon:24/integer-signed-little, Accuracy:3/integer, I:5/integer-unsigned>>, 136) ->
     <<Lon:29/integer-signed-little>> = <<TempLon:24/integer-unsigned-little, I:5/integer-unsigned>>,
-    {ok, #{gns_error => GNSError == 1, gns_fix => GNSFix == 1, moving => Moving == 1, button => Button == 1, battery => (25 + Battery) / 10,
+    {ok, #{gns_error => GNSError == 1, gns_fix => GNSFix == 1, moving => Moving == 1, button => Button == 1, battery => (25 + Battery) / 10, battery_percent => 100 * (BatteryPercent / 15), 
            temperature => Temp - 32, latitude => Lat / 1000000, longitude => Lon / 1000000, accuracy => trunc(math:pow(2, Accuracy+2))}};
 decode(_Decoder, <<0:8/integer, UpdateIntervalWhileMoving:16/integer-unsigned-little, 1:8/integer,
                    KeepAliveIntervalWhileStationary:16/integer-unsigned-little, 2:8/integer,
-                   GSensorTimeoutWhenMoving:16/integer-unsigned-little>>, 204) ->
+                   GSensorTimeoutWhenMoving:16/integer-unsigned-little, _/binary>>, 204) ->
     {ok, #{update_interval_moving => UpdateIntervalWhileMoving,
            keepalive_interval_stationary => KeepAliveIntervalWhileStationary,
            gsensor_timeout_moving => GSensorTimeoutWhenMoving}};


### PR DESCRIPTION
This PR adds battery percentage to the decoder output, and fixes the output for the config status sent on port 204 (the reference manual says its 9 bytes, but it's actually 13 and we don't know what the other 4 bytes are for yet).