### PR TITLE
Determine channel name before handling downlink

### DIFF
--- a/test/utils/console_callback.erl
+++ b/test/utils/console_callback.erl
@@ -212,7 +212,8 @@ websocket_info(_Req, {downlink, Payload}, State) ->
         <<"device:all:downlink:devices">>,
         #{
             <<"devices">> => [?CONSOLE_DEVICE_ID],
-            <<"payload">> => Payload
+            <<"payload">> => Payload,
+            <<"channel_name">> => ?CONSOLE_HTTP_CHANNEL_NAME
         }
     ),
     {reply, {text, Data}, State};


### PR DESCRIPTION
- If there's a problem decoding the body, that will be caught as usual
when queueing the downlink.