### PR TITLE
Fix and check doc-comments in CI

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           SANITIZE_ERLANG_NIFS: 1
         run: ./rebar3 compile
-      
+
       - name: Check formatting
         run: ./rebar3 fmt --verbose --check rebar.config && ./rebar3 fmt --verbose --check "{src,include,test}/**/*.{hrl,erl,app.src}" && ./rebar3 fmt --verbose --check "config/sys.{config,config.src}"
-      
+
       - name: Run xref
         run: ./rebar3 xref
 
@@ -45,3 +45,6 @@ jobs:
 
       - name: Run Dialyzer
         run: ./rebar3 dialyzer
+
+      - name: Check Documentation
+        run: ./rebar3 edoc

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ data/
 src/pb/
 .env
 prometheus.yml
+doc/

--- a/src/lora/lorawan_mac_commands.erl
+++ b/src/lora/lorawan_mac_commands.erl
@@ -1,6 +1,6 @@
 %%%-------------------------------------------------------------------
 %% @doc
-%% Copyright (c) 2016-2019 Petr Gotthard <petr.gotthard@centrum.cz>
+%% Copyright (c) 2016-2019 Petr Gotthard &lt;petr.gotthard@@centrum.cz&gt;
 %% All rights reserved.
 %% Distributed under the terms of the MIT License. See the LICENSE file.
 %% @end

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -1,6 +1,6 @@
 %%%-------------------------------------------------------------------
 %% @doc
-%% Copyright (c) 2016-2019 Petr Gotthard <petr.gotthard@centrum.cz>
+%% Copyright (c) 2016-2019 Petr &lt;Gotthard petr.gotthard@@centrum.cz&gt;
 %% All rights reserved.
 %% Distributed under the terms of the MIT License. See the LICENSE file.
 %% @end

--- a/src/lora/lorawan_utils.erl
+++ b/src/lora/lorawan_utils.erl
@@ -1,6 +1,6 @@
 %%%-------------------------------------------------------------------
 %% @doc
-%% Copyright (c) 2016-2019 Petr Gotthard <petr.gotthard@centrum.cz>
+%% Copyright (c) 2016-2019 Petr Gotthard &lt;petr.gotthard@@centrum.cz&gt;
 %% All rights reserved.
 %% Distributed under the terms of the MIT License. See the LICENSE file.
 %% @end


### PR DESCRIPTION
## Summary

I am currently documenting my ADR branch but I can't check the output because of some unescaped XML in code we inherited from gotthardp.

## Changes

- fix the broken gotthardp doc comments
- add a CI step assertting `rebar3 edoc` returns `0` (success)
