### PR TITLE
Run CI everyday at midnight PST

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,6 +6,10 @@ on:
     tags: '*'
   pull_request:
     branches: master
+  # Run every day at midnight PST (0800 UTC)
+  # https://crontab.guru/#0_8_*_*_*
+  schedule:
+    - cron: '0 8 * * *'
 
 jobs:
   CI:


### PR DESCRIPTION
I am not certain that running a nightly CI would have any effect on this codebase. It could, however, if we have any unconstrained dependencies. Do we?


## Remaining

- [x] allow this PR to sit overnight and make sure the cronjob executes as expected.