### PR TITLE
modify grpc config to use new support for specific proto file list

### DIFF
--- a/config/grpc_client_gen.config
+++ b/config/grpc_client_gen.config
@@ -5,7 +5,9 @@
 ]}.
 
 {grpc, [
-    {protos, ["_build/default/lib/helium_proto/src/service/"]},
+    {proto_files, [
+        "_build/default/lib/helium_proto/src/service/router.proto"
+    ]},
     {out_dir, "src/grpc/autogen/client"},
     {beam_out_dir, "src/grpc/autogen/client"},
     {keep_beams, false},

--- a/config/grpc_server_gen.config
+++ b/config/grpc_server_gen.config
@@ -5,7 +5,9 @@
 ]}.
 
 {grpc, [
-    {protos, ["_build/default/lib/helium_proto/src/service/"]},
+    {proto_files, [
+        "_build/default/lib/helium_proto/src/service/router.proto"
+    ]},
     {out_dir, "src/grpc/autogen/server"},
     {beam_out_dir, "src/grpc/autogen/server"},
     {keep_beams, false},


### PR DESCRIPTION
Simple PR to use latest commits to grpcbox whereby we can now specify which protos we want to generate grpc services for.  Prior to this services for all protos in the protos directory would be automatically generated