### PR TITLE
router support for cn470

### DIFF
--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -23,7 +23,7 @@
 %% @doc === Types and Terms ===
 %%
 %% dr        -> Datarate Index
-%% datar     -> <<"SFxxBWxx">>
+%% datar     -> ```<<"SFxxBWxx">>'''
 %% datarate  -> Datarate Tuple {spreading, bandwidth}
 %%
 %% Frequency -> A Frequency


### PR DESCRIPTION
[Regional Params](https://lora-alliance.org/wp-content/uploads/2020/11/lorawan_regional_parameters_v1.0.3reva_0.pdf) used for CN470, thank you @jmarcelino from #internal-ext-rak.