### PR TITLE
Keep router from falling on its face when hotspots report region_subregion for as923

### DIFF
--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -107,7 +107,6 @@ handle_offer(Offer, HandlerPid) ->
     Resp =
         case Routing of
             #routing_information_pb{data = {eui, _EUI}} ->
-                ok = lorawan_location:maybe_fetch_offer_location(Offer),
                 join_offer(Offer, HandlerPid);
             #routing_information_pb{data = {devaddr, _DevAddr}} ->
                 packet_offer(Offer, HandlerPid)
@@ -122,6 +121,8 @@ handle_offer(Offer, HandlerPid) ->
         ok = print_handle_offer_resp(Offer, HandlerPid, Resp),
         ok = handle_offer_metrics(Routing, Resp, End - Start)
     end),
+    %% TODO: Remove when hotspots start reporting AS923 including subregions
+    ok = lorawan_location:maybe_fetch_offer_location(Offer),
     Resp.
 
 -spec handle_packet(

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1759,6 +1759,10 @@ mk_cflist_for_freqs(Frequencies) ->
 -spec lora_region(atom(), libp2p_crypto:pubkey_bin()) -> atom().
 lora_region(Region, PubKeyBin) ->
     case Region of
+        'AS923_AS1' ->
+            Region;
+        'AS923_AS2' ->
+            Region;
         'AS923' ->
             case lorawan_location:get_country_code(PubKeyBin) of
                 {ok, CountryCode} ->

--- a/src/lora/lorawan_location.erl
+++ b/src/lora/lorawan_location.erl
@@ -65,8 +65,16 @@ start_link() ->
 -spec maybe_fetch_offer_location(blockchain_state_channel_offer_v1:offer()) -> ok.
 maybe_fetch_offer_location(Offer) ->
     case blockchain_state_channel_offer_v1:region(Offer) of
-        'AS923' -> gen_server:cast(?SERVER, {fetch, Offer});
-        _ -> ok
+        'AS923' ->
+            PubKeyBin = blockchain_state_channel_offer_v1:hotspot(Offer),
+            case get_country_code(PubKeyBin) of
+                {error, pubkey_not_present} ->
+                    gen_server:cast(?SERVER, {fetch, Offer});
+                {ok, _} ->
+                    ok
+            end;
+        _ ->
+            ok
     end.
 
 -spec get_country_code(libp2p_crypto:pubkey_bin()) -> {ok, country_code()} | {error, any()}.


### PR DESCRIPTION
- Hotspots are planing on reporting their subregion as part of AS923, if
they provide, we should respect that.

- Move maybe fetching locations back to every offer. If router is
redeployed and a device does not try to join again, we won't know what
region it's in.