### PR TITLE
Handle ack_timeout error in mqtt channel

### DIFF
--- a/src/channels/router_mqtt_channel.erl
+++ b/src/channels/router_mqtt_channel.erl
@@ -209,7 +209,15 @@ handle_info(
     try ping(Conn) of
         ok ->
             lager:debug("[~s] pinged MQTT connection ~p successfully", [ChannelID, Conn]),
-            {ok, State#state{ping = schedule_ping(ChannelID)}}
+            {ok, State#state{ping = schedule_ping(ChannelID)}};
+        {error, _Reason} ->
+            lager:error("[~s] failed to ping MQTT connection ~p: ~p", [
+                ChannelID,
+                Conn,
+                _Reason
+            ]),
+            Backoff1 = reconnect(ChannelID, Backoff0),
+            {ok, State#state{connection_backoff = Backoff1}}
     catch
         _Class:_Reason ->
             lager:error("[~s] failed to ping MQTT connection ~p: ~p", [


### PR DESCRIPTION
```
{'EXIT',{{try_clause,{error,ack_timeout}}, [{router_mqtt_channel,handle_info,2, [{file,"/opt/router/src/channels/router_mqtt_channel.erl"}, {line,209}]}, {gen_event,server_update,4,[{file,"gen_event.erl"},{line,577}]}, {gen_event,server_notify,4,[{file,"gen_event.erl"},{line,559}]}, {gen_event,server_notify,4,[{file,"gen_event.erl"},{line,561}]}, {gen_event,handle_msg,6,[{file,"gen_event.erl"},{line,347}]}, {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}}```