### PR TITLE
Fix rx2_window for AU915

### DIFF
--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -214,7 +214,7 @@ rx2_window(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AS923' ->
         codr = RxQ#rxq.codr
     };
 %% 923.3. MHz / DR8 (SF12, 500 kHz)
-rx2_window(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AS923' ->
+rx2_window(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AU915' ->
     Delay = get_window(?FUNCTION_NAME),
     #txq{
         freq = 923.3,


### PR DESCRIPTION
```
    exception exit: {{function_clause,[{lorawan_mac_region,f2uch,[926.3,{9152,2},{9159,16}],[{file,"/opt/router/src/lora/lorawan_mac_region.erl"},{line,289}]},{router_utils,format_hotspot,6,[{file,"/opt/router/src/router_utils.erl"},{line,80}]},{router_device_utils,report_join_accept,4,[{file,"/opt/router/src/device/router_device_utils.erl"},{line,487}]},{router_device_worker,handle_info,2,[{file,"/opt/router/src/device/router_device_worker.erl"},{line,584}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,637}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,711}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]},[{gen_event,terminate_server,4,[{file,"gen_event.erl"},{line,354}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
    ancestors: [<0.13674.5>,<0.13673.5>,router_devices_sup,router_sup,<0.1447.0>]```