### PR TITLE
Improve trace logging

### DIFF
--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -375,10 +375,7 @@ maybe_buy_join_offer(Offer, _Pid, Device) ->
                     PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
                     case bloom:set(BFRef, PHash) of
                         true ->
-                            case maybe_multi_buy(Offer, 10, Device) of
-                                ok -> ok;
-                                {error, _} = Error -> Error
-                            end;
+                            maybe_multi_buy(Offer, 10, Device);
                         false ->
                             true = ets:insert(?MB_ETS, {PHash, ?JOIN_MAX, 1}),
                             DeviceID = router_device:id(Device),

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -967,7 +967,7 @@ get_chain() ->
     end.
 
 -spec handle_offer_metrics(
-    #router_information_pb{},
+    #routing_information_pb{},
     {ok, router_device:device()} | {error, any()},
     non_neg_integer()
 ) -> ok.

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -970,7 +970,7 @@ get_chain() ->
     end.
 
 -spec handle_offer_metrics(
-    any(),
+    #router_information_pb{},
     {ok, router_device:device()} | {error, any()},
     non_neg_integer()
 ) -> ok.

--- a/src/router_utils.erl
+++ b/src/router_utils.erl
@@ -119,6 +119,14 @@ trace(DeviceID) ->
         ],
         debug
     ),
+    {ok, _} = lager:trace_file(
+        FileName,
+        [
+            {module, router_device_routing},
+            {device_id, router_device:id(Device)}
+        ],
+        debug
+    ),
     ok.
 
 -spec stop_trace(DeviceID :: binary()) -> ok.


### PR DESCRIPTION
This is to improve device log tracing by providing device id when possible to avoid having duplicate messages from other device sharing same `devaddr`