### PR TITLE
Michaeljeffrey/more logs

### DIFF
--- a/src/channels/router_mqtt_channel.erl
+++ b/src/channels/router_mqtt_channel.erl
@@ -469,7 +469,7 @@ connect(URI, DeviceID, Name) ->
                     {error, Reason}
             end;
         _ ->
-            lager:info("BAD MQTT URI ~s for channel ~s ~p", [URI, Name]),
+            lager:info("BAD MQTT URI ~p for channel ~p", [URI, Name]),
             {error, invalid_mqtt_uri}
     end.
 

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -791,6 +791,7 @@ handle_info(
         binary_to_list(TxDataRate),
         Rx2
     ),
+    lager:debug("sending join response ~p", [DownlinkPacket]),
     catch blockchain_state_channel_handler:send_response(
         Pid,
         blockchain_state_channel_response_v1:new(true, DownlinkPacket)
@@ -847,6 +848,7 @@ handle_info(
     of
         {ok, Device1} ->
             ok = save_and_update(DB, CF, ChannelsWorker, Device1),
+            lager:debug("sending frame response with no downlink"),
             catch blockchain_state_channel_handler:send_response(
                 Pid,
                 blockchain_state_channel_response_v1:new(true)
@@ -888,7 +890,7 @@ handle_info(
                 _ -> router_device_routing:clear_replay(DeviceID)
             end,
             ok = save_and_update(DB, CF, ChannelsWorker, Device1),
-            lager:debug("sending downlink for fcnt: ~p", [FCnt]),
+            lager:debug("sending downlink for fcnt: ~p, ~p", [FCnt, DownlinkPacket]),
             catch blockchain_state_channel_handler:send_response(
                 Pid,
                 blockchain_state_channel_response_v1:new(true, DownlinkPacket)


### PR DESCRIPTION
Some orgs have lots of devices, and when the logs are streaming by it's
hard to tell how many things are pending.

This could also help us determine if orgs are triggering updates while
updates are already going.

There's around ~9k devices on prod (as of this writing). We update 1
device at a time to keep from hammering console. That could take around
2.5 hours to update everything

trying to debug timestamps, and we wished we had the response we were
sending to the devices in the logs without having to go to the device
