### PR TITLE
Accept url_params in channel updates

### DIFF
--- a/src/channels/router_http_channel.erl
+++ b/src/channels/router_http_channel.erl
@@ -91,9 +91,16 @@ handle_event(_Msg, State) ->
     {ok, State}.
 
 handle_call({update, Channel, _Device}, State) ->
-    #{url := URL, headers := Headers0, method := Method} = router_channel:args(Channel),
+    Args = #{url := URL, headers := Headers0, method := Method} = router_channel:args(Channel),
+    UrlParams = maps:get(url_params, Args, []),
     Headers1 = content_type_or_default(Headers0),
-    {ok, ok, State#state{channel = Channel, url = URL, headers = Headers1, method = Method}};
+    {ok, ok, State#state{
+        channel = Channel,
+        url = URL,
+        headers = Headers1,
+        method = Method,
+        url_params = UrlParams
+    }};
 handle_call(_Msg, State) ->
     lager:warning("rcvd unknown call msg: ~p", [_Msg]),
     {ok, ok, State}.


### PR DESCRIPTION
- add a test for making sure url_params get absorbed
- quick note that headers don't need to be treated like a jsx_map
  because we always default to sending content-type if nothing is
  provided. Headers should never be empty in the request, even if it's
  empty in the channel args.