### PR TITLE
Up sc_open_failure to warning from debug

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -127,7 +127,8 @@
             {lager_console_backend, [{module, router_device_routing}], info},
             {{lager_file_backend, "router.log"}, [{application, router}], info},
             {{lager_file_backend, "router.log"}, [{module, router_console_api}], info},
-            {{lager_file_backend, "router.log"}, [{module, router_device_routing}], info}
+            {{lager_file_backend, "router.log"}, [{module, router_device_routing}], info},
+            {{lager_file_backend, "state_channel.log"}, [{module, router_sc_worker}], debug}
         ]}
     ]}
 ].

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -132,7 +132,8 @@
             {lager_console_backend, [{module, router_device_routing}], info},
             {{lager_file_backend, "router.log"}, [{application, router}], info},
             {{lager_file_backend, "router.log"}, [{module, router_console_api}], info},
-            {{lager_file_backend, "router.log"}, [{module, router_device_routing}], info}
+            {{lager_file_backend, "router.log"}, [{module, router_device_routing}], info},
+            {{lager_file_backend, "state_channel.log"}, [{module, router_sc_worker}], debug}
         ]}
     ]}
 ].

--- a/src/router_sc_worker.erl
+++ b/src/router_sc_worker.erl
@@ -175,7 +175,7 @@ handle_info({sc_open_success, Id}, #state{is_active = true, tombstones = T} = St
     lager:debug("sc_open_success for txn id ~p", [Id]),
     {noreply, State#state{tombstones = [Id | T]}};
 handle_info({sc_open_failure, Error, Id}, #state{is_active = true, tombstones = T} = State) ->
-    lager:debug("sc_open_failure ~p for txn id ~p", [Error, Id]),
+    lager:warning("sc_open_failure ~p for txn id ~p", [Error, Id]),
     %% we're not going to immediately try to start a new channel, we will
     %% wait until the next tick to evaluate that decision.
     {noreply, State#state{tombstones = [Id | T]}};


### PR DESCRIPTION
- If state channels are failing to open we want to be able to see that
information without asking.

- While scs are being worked on, it might be nice to give them their own
log file.