### PR TITLE
Michaeljeffrey/as923 updates

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1222,10 +1222,16 @@ craft_join_reply(Region, AppNonce, DevAddr, AppKey) ->
                 %% The actual channel frequency in Hz is 100 x frequency whereby values representing
                 %% frequencies below 100 MHz are reserved for future use.
                 mk_cflist_for_freqs([8671000, 8673000, 8675000, 8677000, 8679000]);
-            'AS923_AS1' ->
+            'AS923_1' ->
                 mk_cflist_for_freqs([9222000, 9224000, 9226000, 9228000, 9230000]);
-            'AS923_AS2' ->
+            'AS923_2' ->
                 mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9246000]);
+            'AS923_3' ->
+                %% TODO:
+                <<>>;
+            'AS923_4' ->
+                %% TODO:
+                <<>>;
             _ ->
                 %% Not yet implemented for other regions
                 <<>>

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -2098,7 +2098,7 @@ lora_region(Region, PubKeyBin) ->
                         ]
                     ),
                     %% Default to AS923 region with more countries
-                    'AS923_AS2'
+                    'AS923_2'
             end;
         _ ->
             Region

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1223,15 +1223,13 @@ craft_join_reply(Region, AppNonce, DevAddr, AppKey) ->
                 %% frequencies below 100 MHz are reserved for future use.
                 mk_cflist_for_freqs([8671000, 8673000, 8675000, 8677000, 8679000]);
             'AS923_1' ->
-                mk_cflist_for_freqs([9222000, 9224000, 9226000, 9228000, 9230000]);
+                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
             'AS923_2' ->
-                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9246000]);
+                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
             'AS923_3' ->
-                %% TODO:
-                <<>>;
+                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
             'AS923_4' ->
-                %% TODO:
-                <<>>;
+                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
             _ ->
                 %% Not yet implemented for other regions
                 <<>>

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1225,11 +1225,11 @@ craft_join_reply(Region, AppNonce, DevAddr, AppKey) ->
             'AS923_1' ->
                 mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
             'AS923_2' ->
-                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
+                mk_cflist_for_freqs([9218000, 9220000, 9222000, 9224000, 9226000]);
             'AS923_3' ->
-                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
+                mk_cflist_for_freqs([9170000, 9172000, 9174000, 9176000, 9178000]);
             'AS923_4' ->
-                mk_cflist_for_freqs([9236000, 9238000, 9240000, 9242000, 9244000]);
+                mk_cflist_for_freqs([9177000, 9179000, 9181000, 9183000, 9185000]);
             _ ->
                 %% Not yet implemented for other regions
                 <<>>

--- a/src/lora/lorawan_location.erl
+++ b/src/lora/lorawan_location.erl
@@ -36,19 +36,19 @@
 -define(ETS, lorawan_region_location_ets).
 -define(HOTSPOT_URL_PREFIX, "https://api.helium.io/v1/hotspots/").
 
--define(AS923_UNKNOWN_REGION_DEFAULT, 'AS923_AS2').
+-define(AS923_UNKNOWN_REGION_DEFAULT, 'AS923_2').
 -define(AS923_REGION_MAPPING, #{
-    {<<"JP">>, <<"Japan">>} => 'AS923_AS1',
-    {<<"MY">>, <<"Malaysia">>} => 'AS923_AS1',
-    {<<"SG">>, <<"Singapore">>} => 'AS923_AS1',
-    {<<"BN">>, <<"Brunei">>} => 'AS923_AS2',
-    {<<"KH">>, <<"Cambodia">>} => 'AS923_AS2',
-    {<<"HK">>, <<"Hong Kong">>} => 'AS923_AS2',
-    {<<"ID">>, <<"Indonesia">>} => 'AS923_AS2',
-    {<<"LA">>, <<"Laos">>} => 'AS923_AS2',
-    {<<"TW">>, <<"Taiwan">>} => 'AS923_AS2',
-    {<<"TH">>, <<"Thailand">>} => 'AS923_AS2',
-    {<<"VN">>, <<"Vietnam">>} => 'AS923_AS2'
+    {<<"JP">>, <<"Japan">>} => 'AS923_1',
+    {<<"MY">>, <<"Malaysia">>} => 'AS923_1',
+    {<<"SG">>, <<"Singapore">>} => 'AS923_1',
+    {<<"BN">>, <<"Brunei">>} => 'AS923_2',
+    {<<"KH">>, <<"Cambodia">>} => 'AS923_2',
+    {<<"HK">>, <<"Hong Kong">>} => 'AS923_2',
+    {<<"ID">>, <<"Indonesia">>} => 'AS923_2',
+    {<<"LA">>, <<"Laos">>} => 'AS923_2',
+    {<<"TW">>, <<"Taiwan">>} => 'AS923_2',
+    {<<"TH">>, <<"Thailand">>} => 'AS923_2',
+    {<<"VN">>, <<"Vietnam">>} => 'AS923_2'
 }).
 
 -type country_code() :: {binary(), binary()}.
@@ -88,7 +88,8 @@ store(PubKeyBin, CountryCode) ->
     true = ets:insert(?ETS, {PubKeyBin, CountryCode}),
     ok.
 
--spec as923_region_from_country_code(country_code()) -> 'AS923_AS1' | 'AS923_AS2'.
+-spec as923_region_from_country_code(country_code()) ->
+    'AS923_1' | 'AS923_2' | 'AS923_3' | 'AS923_4'.
 as923_region_from_country_code(CountryCode) ->
     maps:get(CountryCode, ?AS923_REGION_MAPPING, ?AS923_UNKNOWN_REGION_DEFAULT).
 

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -251,39 +251,44 @@ rx1_rf(Region, #rxq{freq = Freq} = RxQ, Offset) ->
 
 -spec rx2_rf(atom(), #rxq{}) -> #txq{}.
 %% 923.3MHz / DR8 (SF12 BW500)
-rx2_rf(Region, #rxq{codr = Codr}) when Region == 'US915' ->
+rx2_rf(Region, #rxq{codr = Codr, time = Time}) when Region == 'US915' ->
     #txq{
         freq = 923.3,
         datr = dr_to_datar(Region, 8),
-        codr = Codr
+        codr = Codr,
+        time = Time
     };
 %% 505.3 MHz / DR0 (SF12 / BW125)
-rx2_rf(Region, #rxq{codr = Codr}) when Region == 'CN470' ->
+rx2_rf(Region, #rxq{codr = Codr, time = Time}) when Region == 'CN470' ->
     #txq{
         freq = 505.3,
         datr = dr_to_datar(Region, 0),
-        codr = Codr
+        codr = Codr,
+        time = Time
     };
 %% 869.525 MHz / DR0 (SF12, 125 kHz)
-rx2_rf(Region, #rxq{codr = Codr}) when Region == 'EU868' ->
+rx2_rf(Region, #rxq{codr = Codr, time = Time}) when Region == 'EU868' ->
     #txq{
         freq = 869.525,
         datr = dr_to_datar(Region, 0),
-        codr = Codr
+        codr = Codr,
+        time = Time
     };
 %% 923.2. MHz / DR2 (SF10, 125 kHz)
-rx2_rf(Region, #rxq{codr = Codr}) when Region == 'AS923' ->
+rx2_rf(Region, #rxq{codr = Codr, time = Time}) when Region == 'AS923' ->
     #txq{
         freq = 923.2,
         datr = dr_to_datar(Region, 2),
-        codr = Codr
+        codr = Codr,
+        time = Time
     };
 %% 923.3. MHz / DR8 (SF12, 500 kHz)
-rx2_rf(Region, #rxq{codr = Codr}) when Region == 'AU915' ->
+rx2_rf(Region, #rxq{codr = Codr, time = Time}) when Region == 'AU915' ->
     #txq{
         freq = 923.3,
         datr = dr_to_datar(Region, 8),
-        codr = Codr
+        codr = Codr,
+        time = Time
     }.
 
 %% ------------------------------------------------------------------

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -128,22 +128,26 @@
 -spec join1_window(atom(), integer(), #rxq{}) -> #txq{}.
 join1_window(Region, _Delay, RxQ) ->
     TopLevelRegion = top_level_region(Region),
-    tx_window(?FUNCTION_NAME, RxQ, rx1_rf(TopLevelRegion, RxQ, 0)).
+    TxQ = rx1_rf(TopLevelRegion, RxQ, 0),
+    tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
 -spec join2_window(atom(), #rxq{}) -> #txq{}.
 join2_window(Region, RxQ) ->
     TopLevelRegion = top_level_region(Region),
-    join2_window_(TopLevelRegion, RxQ).
+    TxQ = rx2_rf(TopLevelRegion, RxQ),
+    tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
 -spec rx1_window(atom(), number(), number(), #rxq{}) -> #txq{}.
 rx1_window(Region, _Delay, Offset, RxQ) ->
     TopLevelRegion = top_level_region(Region),
-    tx_window(?FUNCTION_NAME, RxQ, rx1_rf(TopLevelRegion, RxQ, Offset)).
+    TxQ = rx1_rf(TopLevelRegion, RxQ, Offset),
+    tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
 -spec rx2_window(atom(), #rxq{}) -> #txq{}.
 rx2_window(Region, RxQ) ->
     TopLevelRegion = top_level_region(Region),
-    rx2_window_(TopLevelRegion, RxQ).
+    TxQ = rx2_rf(TopLevelRegion, RxQ),
+    tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
 %% ------------------------------------------------------------------
 %% Region Wrapped Helper Functions
@@ -226,118 +230,61 @@ top_level_region(Region) -> Region.
 %% See RP002-1.0.1 LoRaWAN® Regional
 %% For CN470 See lorawan_regional_parameters_v1.0.3reva_0.pdf
 
--spec join2_window_(atom(), #rxq{}) -> #txq{}.
-%% 923.3MHz / DR8 (SF12 BW500)
-join2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'US915' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 923.3,
-        datr = dr_to_datar(Region, 8),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 505.3 MHz / DR0 (SF12 / BW125)
-join2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'CN470' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 505.3,
-        datr = dr_to_datar(Region, 0),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 869.525 MHz / DR0 (SF12, 125 kHz)
-join2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'EU868' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 869.525,
-        datr = dr_to_datar(Region, 0),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 923.2. MHz / DR2 (SF10, 125 kHz)
-join2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AS923' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 923.2,
-        datr = dr_to_datar(Region, 2),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-join2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AU915' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 923.3,
-        datr = dr_to_datar(Region, 8),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    }.
-
-%% See RP002-1.0.1 LoRaWAN® Regional
--spec rx2_window_(atom(), #rxq{}) -> #txq{}.
-%% 923.3MHz / DR8 (SF12 BW500)
-rx2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'US915' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 923.3,
-        datr = dr_to_datar(Region, 8),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 505.3 MHz / DR0 (SF12 / BW125)
-rx2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'CN470' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 505.3,
-        datr = dr_to_datar(Region, 0),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 869.525 MHz / DR0 (SF12, 125 kHz)
-rx2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'EU868' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 869.525,
-        datr = dr_to_datar(Region, 0),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 923.2. MHz / DR2 (SF10, 125 kHz)
-rx2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AS923' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 923.2,
-        datr = dr_to_datar(Region, 2),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    };
-%% 923.3. MHz / DR8 (SF12, 500 kHz)
-rx2_window_(Region, #rxq{tmms = Stamp} = RxQ) when Region == 'AU915' ->
-    Delay = get_window(?FUNCTION_NAME),
-    #txq{
-        freq = 923.3,
-        datr = dr_to_datar(Region, 8),
-        time = Stamp + Delay,
-        codr = RxQ#rxq.codr
-    }.
-
 -spec rx1_rf(atom(), #rxq{}, number()) -> #txq{}.
 %% we calculate in fixed-point numbers
-rx1_rf('US915' = Region, RxQ, Offset) ->
-    RxCh = f2uch_(RxQ#rxq.freq, {9023, 2}, {9030, 16}),
+rx1_rf(Region, #rxq{freq = Freq} = RxQ, Offset) when Region == 'US915' ->
+    RxCh = f2uch_(Freq, {9023, 2}, {9030, 16}),
     DownFreq = dch2f(Region, RxCh rem 8),
     tx_offset(Region, RxQ, DownFreq, Offset);
-rx1_rf('AU915' = Region, RxQ, Offset) ->
-    RxCh = f2uch_(RxQ#rxq.freq, {9152, 2}, {9159, 16}),
+rx1_rf(Region, #rxq{freq = Freq} = RxQ, Offset) when Region == 'AU915' ->
+    RxCh = f2uch_(Freq, {9152, 2}, {9159, 16}),
     DownFreq = dch2f(Region, RxCh rem 8),
     tx_offset(Region, RxQ, DownFreq, Offset);
-rx1_rf('CN470' = Region, RxQ, Offset) ->
-    RxCh = f2uch(RxQ#rxq.freq, {4703, 2}),
+rx1_rf(Region, #rxq{freq = Freq} = RxQ, Offset) when Region == 'CN470' ->
+    RxCh = f2uch(Freq, {4703, 2}),
     DownFreq = dch2f(Region, RxCh rem 48),
     tx_offset(Region, RxQ, DownFreq, Offset);
-rx1_rf('AS923' = Region, RxQ, Offset) ->
-    tx_offset(Region, RxQ, RxQ#rxq.freq, Offset);
-rx1_rf(Region, RxQ, Offset) ->
-    tx_offset(Region, RxQ, RxQ#rxq.freq, Offset).
+rx1_rf(Region, #rxq{freq = Freq} = RxQ, Offset) when Region == 'AS923' ->
+    tx_offset(Region, RxQ, Freq, Offset);
+rx1_rf(Region, #rxq{freq = Freq} = RxQ, Offset) ->
+    tx_offset(Region, RxQ, Freq, Offset).
+
+-spec rx2_rf(atom(), #rxq{}) -> #txq{}.
+%% 923.3MHz / DR8 (SF12 BW500)
+rx2_rf(Region, #rxq{codr = Codr}) when Region == 'US915' ->
+    #txq{
+        freq = 923.3,
+        datr = dr_to_datar(Region, 8),
+        codr = Codr
+    };
+%% 505.3 MHz / DR0 (SF12 / BW125)
+rx2_rf(Region, #rxq{codr = Codr}) when Region == 'CN470' ->
+    #txq{
+        freq = 505.3,
+        datr = dr_to_datar(Region, 0),
+        codr = Codr
+    };
+%% 869.525 MHz / DR0 (SF12, 125 kHz)
+rx2_rf(Region, #rxq{codr = Codr}) when Region == 'EU868' ->
+    #txq{
+        freq = 869.525,
+        datr = dr_to_datar(Region, 0),
+        codr = Codr
+    };
+%% 923.2. MHz / DR2 (SF10, 125 kHz)
+rx2_rf(Region, #rxq{codr = Codr}) when Region == 'AS923' ->
+    #txq{
+        freq = 923.2,
+        datr = dr_to_datar(Region, 2),
+        codr = Codr
+    };
+%% 923.3. MHz / DR8 (SF12, 500 kHz)
+rx2_rf(Region, #rxq{codr = Codr}) when Region == 'AU915' ->
+    #txq{
+        freq = 923.3,
+        datr = dr_to_datar(Region, 8),
+        codr = Codr
+    }.
 
 %% ------------------------------------------------------------------
 %% @doc Frequency to Up Channel


### PR DESCRIPTION
Miners are going to start reporting subregions for AS923 bands. 
Outside of joining, the lora spec doesn't differentiate between the sub-regions.
So we intercept the region and map it to the top level region before continuing. 
This lets the device remain as ignorant as possible that it might be carrying a region with extra information. And we get to keep the subregions for potential debugging help.

#### Still need:
- [x] Frequency Lists for Subregions `3` and `4`