### PR TITLE
Fix datarate used when queueing downlinks

### DIFF
--- a/src/device/router_device.erl
+++ b/src/device/router_device.erl
@@ -411,11 +411,12 @@ deserialize(Binary) ->
 can_queue_payload(_Payload, #device_v6{region = undefined}) ->
     {error, device_region_unknown};
 can_queue_payload(Payload, Device) ->
-    DR = ?MODULE:last_known_datarate(Device),
     Region = ?MODULE:region(Device),
-    MaxSize = lorawan_mac_region:max_payload_size(Region, DR),
+    UpDR = ?MODULE:last_known_datarate(Device),
+    DownDR = lorawan_mac_region:dr_to_down(Region, UpDR, 0),
+    MaxSize = lorawan_mac_region:max_payload_size(Region, DownDR),
     Size = erlang:byte_size(Payload),
-    {Size < MaxSize, Size, MaxSize, DR}.
+    {Size < MaxSize, Size, MaxSize, DownDR}.
 
 %% ------------------------------------------------------------------
 %% RocksDB Device Functions

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -18,6 +18,7 @@
 -export([uplink_power_table/1]).
 -export([max_payload_size/2]).
 -export([downlink_signal_strength/1]).
+-export([dr_to_down/3]).
 
 -include("lorawan_db.hrl").
 

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -375,11 +375,20 @@ drop_downlink_test(Config) ->
     Msg = #downlink{confirmed = true, port = 2, payload = Payload, channel = Channel},
     ok = router_device_worker:queue_message(DeviceWorkerPid, Msg),
 
+    DatarateDown = lorawan_mac_region:dr_to_down('US915', 2, 0),
+    MaxSize = lorawan_mac_region:max_payload_size('US915', DatarateDown),
+    Description = erlang:list_to_binary(
+        io_lib:format("Payload too big for DR~p max size is ~p (payload was 243)", [
+            DatarateDown,
+            MaxSize
+        ])
+    ),
+
     test_utils:wait_for_console_event_sub(<<"downlink_dropped_payload_size_exceeded">>, #{
         <<"id">> => fun erlang:is_binary/1,
         <<"category">> => <<"downlink_dropped">>,
         <<"sub_category">> => <<"downlink_dropped_payload_size_exceeded">>,
-        <<"description">> => <<"Payload too big for DR2 max size is 125 (payload was 243)">>,
+        <<"description">> => Description,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"device_id">> => ?CONSOLE_DEVICE_ID,
         <<"data">> => #{


### PR DESCRIPTION
We track the uplink datarates for devices. We were not using the mapped
datarate for downlinks when seeing if a payload can be queued. Uplinks
are tighter on size than downlinks are in most cases.