### PR TITLE
Always send base64 payloads for queue updates

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1057,7 +1057,7 @@ downlink_to_map(Downlink) ->
     #{
         confirmed => Downlink#downlink.confirmed,
         port => Downlink#downlink.port,
-        payload => Downlink#downlink.payload,
+        payload => base64:encode(Downlink#downlink.payload),
         channel => router_channel:to_map(Downlink#downlink.channel)
     }.
 

--- a/test/router_console_api_SUITE.erl
+++ b/test/router_console_api_SUITE.erl
@@ -144,7 +144,7 @@ consume_queue_test(Config) ->
                                 <<"name">> => router_channel:name(Channel)
                             },
                             <<"confirmed">> => Downlink1#downlink.confirmed,
-                            <<"payload">> => Downlink1#downlink.payload,
+                            <<"payload">> => base64:encode(Downlink1#downlink.payload),
                             <<"port">> => Downlink1#downlink.port
                         }
                     ]
@@ -170,7 +170,7 @@ consume_queue_test(Config) ->
                                 <<"name">> => router_channel:name(Channel)
                             },
                             <<"confirmed">> => Downlink1#downlink.confirmed,
-                            <<"payload">> => Downlink1#downlink.payload,
+                            <<"payload">> => base64:encode(Downlink1#downlink.payload),
                             <<"port">> => Downlink1#downlink.port
                         },
                         #{
@@ -179,7 +179,7 @@ consume_queue_test(Config) ->
                                 <<"name">> => router_channel:name(Channel)
                             },
                             <<"confirmed">> => Downlink2#downlink.confirmed,
-                            <<"payload">> => Downlink2#downlink.payload,
+                            <<"payload">> => base64:encode(Downlink2#downlink.payload),
                             <<"port">> => Downlink2#downlink.port
                         }
                     ]
@@ -219,7 +219,7 @@ consume_queue_test(Config) ->
                                 <<"name">> => router_channel:name(Channel)
                             },
                             <<"confirmed">> => Downlink2#downlink.confirmed,
-                            <<"payload">> => Downlink2#downlink.payload,
+                            <<"payload">> => base64:encode(Downlink2#downlink.payload),
                             <<"port">> => Downlink2#downlink.port
                         }
                     ]
@@ -298,7 +298,7 @@ fetch_queue_test(Config) ->
                                 <<"name">> => router_channel:name(Channel)
                             },
                             <<"confirmed">> => Downlink1#downlink.confirmed,
-                            <<"payload">> => Downlink1#downlink.payload,
+                            <<"payload">> => base64:encode(Downlink1#downlink.payload),
                             <<"port">> => Downlink1#downlink.port
                         }
                     ]
@@ -324,7 +324,7 @@ fetch_queue_test(Config) ->
                                 <<"name">> => router_channel:name(Channel)
                             },
                             <<"confirmed">> => Downlink1#downlink.confirmed,
-                            <<"payload">> => Downlink1#downlink.payload,
+                            <<"payload">> => base64:encode(Downlink1#downlink.payload),
                             <<"port">> => Downlink1#downlink.port
                         }
                     ]


### PR DESCRIPTION
We're attempting to simplify the interactions with queuing downlinks
through console. Queuing through an endpoint or payload_raw we assume
the user is giving us a base64 encoded payload, router decodes and
stores, then sends that to Console (when queue updates are active).

Queueing downlinks through Console are base64 as well, sometimes.
To simplify we're building the contract that router will send whatever
it received back to Console, no need to think about who encoded or
decoded when or where.

Let me know if there's something I've missed thinking about. I have a nag there might be, but can't pinpoint it.