### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -29,8 +29,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build
-        env:
-          SANITIZE_ERLANG_NIFS: 1
         run: |
           ./rebar3 get-deps
           REBAR_CONFIG="config/grpc_server_gen.config" ./rebar3 grpc gen
@@ -47,19 +45,10 @@ jobs:
         run: ./rebar3 xref
 
       - name: Run EUnit tests
-        env:
-          SANITIZE_ERLANG_NIFS: 1
-          ASAN_OPTIONS: detect_leaks=0
-        run: LD_PRELOAD="$(cc --print-file libasan.so)" ./rebar3 eunit
+        run: ./rebar3 eunit
 
       - name: Run CT tests
-        env:
-          SANITIZE_ERLANG_NIFS: 1
-          # We turn off leak detection to reduce noise from leaking
-          # processes that rebar exec()s before it actually runs the
-          # tests.
-          ASAN_OPTIONS: detect_leaks=0
-        run: LD_PRELOAD="$(cc --print-file libasan.so)" ./rebar3 ct
+        run: ./rebar3 ct
 
       - name: Run Dialyzer
         run: ./rebar3 dialyzer


### PR DESCRIPTION
Address sanitizer seems to not play well with `rustc` itself. I'd prefer to leave ASan enabled, but we run all our c NIFs' tests with it enabled, so we still have a little protection.