### PR TITLE
Fix NetID parsing

### DIFF
--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -1095,7 +1095,7 @@ handle_offer_metrics(#routing_information_pb{data = {devaddr, DevAddr}}, {ok, _}
     ok = router_metrics:routing_offer_observe(packet, accepted, accepted, Time),
     ok =
         case router_device_devaddr:net_id(DevAddr) of
-            {ok, NetID, _Type} ->
+            {ok, NetID} ->
                 router_metrics:network_id_inc(erlang:integer_to_list(NetID));
             {error, _} ->
                 router_metrics:network_id_inc("invalid_net_id")
@@ -1107,7 +1107,7 @@ handle_offer_metrics(
 ) ->
     ok =
         case router_device_devaddr:net_id(DevAddr) of
-            {ok, NetID, _Type} ->
+            {ok, NetID} ->
                 router_metrics:network_id_inc(erlang:integer_to_list(NetID));
             {error, _} ->
                 router_metrics:network_id_inc("invalid_net_id")


### PR DESCRIPTION
The Type tells you how many bits to read for the netid, but it also
tells you what to prefix the 24bit NetID with to get the resulting NetID.