### PR TITLE
Move crafting reply closer to sending join

### DIFF
--- a/include/router_device_worker.hrl
+++ b/include/router_device_worker.hrl
@@ -12,10 +12,17 @@
     data
 }).
 
+-record(join_accept_args, {
+    region :: atom(),
+    app_nonce :: binary(),
+    dev_addr :: binary(),
+    app_key :: binary()
+}).
+
 -record(join_cache, {
     uuid :: router_utils:uuid_v4(),
     rssi :: float(),
-    reply :: binary(),
+    join_accept_args :: #join_accept_args{},
     packet_selected ::
         {blockchain_helium_packet_v1:packet(), libp2p_crypto:pubkey_bin(), atom(),
             non_neg_integer()},

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -32,7 +32,7 @@
 -export([downlink_signal_strength/1]).
 -export([dr_to_down/3]).
 -export([window2_dr/1, top_level_region/1, f2uch/2]).
--export([mk_join_accept_cf_list/1]).
+-export([mk_join_accept_cf_list/2]).
 
 -include("lorawan_db.hrl").
 
@@ -763,6 +763,16 @@ max_snr(SF) ->
 %% CFList functions
 %% -------------------------------------------------------------------
 
+-spec mk_join_accept_cf_list(atom(), integer()) -> binary().
+mk_join_accept_cf_list('US915' = Region, Count) ->
+    case (Count rem 2) == 0 of
+        true -> mk_join_accept_cf_list(Region);
+        false -> <<>>
+    end;
+mk_join_accept_cf_list(Region, _Count) ->
+    mk_join_accept_cf_list(Region).
+
+-spec mk_join_accept_cf_list(atom()) -> binary().
 mk_join_accept_cf_list('US915') ->
     %% https://lora-alliance.org/wp-content/uploads/2021/05/RP-2-1.0.3.pdf
     %% Page 33
@@ -1203,7 +1213,13 @@ bits_test_() ->
 us915_join_accept_cf_list_structure_test() ->
     Bin = mk_join_accept_cf_list('US915'),
     ?assertEqual(16, erlang:byte_size(Bin), "Correct size"),
-    ?assertEqual(1, binary:last(Bin), "CFListType field SHALL contain the value 0x01").
+    ?assertEqual(1, binary:last(Bin), "CFListType field SHALL contain the value 0x01"),
+    ?assertNotEqual(
+        mk_join_accept_cf_list('US915', _JoinAttempt0 = 0),
+        mk_join_accept_cf_list('US915', _JoinAttempt1 = 1),
+        "A/B join attempt cflists to allow old devices a chance to join"
+    ),
+    ok.
 
 mk_join_accept_cf_list_test_() ->
     [

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -11,6 +11,7 @@
     dupes_test/1,
     dupes2_test/1,
     join_test/1,
+    us915_join_cf_list_test/1,
     adr_test/1
 ]).
 
@@ -41,6 +42,7 @@ all() ->
     [
         dupes_test,
         join_test,
+        us915_join_cf_list_test,
         adr_test
     ].
 
@@ -726,7 +728,7 @@ join_test(Config) ->
         AppKey,
         DevNonce
     ),
-    ?assertEqual(CFList, lorawan_mac_region:mk_join_accept_cf_list('US915')),
+    ?assertEqual(CFList, lorawan_mac_region:mk_join_accept_cf_list('US915', _FirstJoinAttempt = 0)),
     %% Check that device is in cache now
     {ok, DB, [_, CF]} = router_db:get(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
@@ -780,6 +782,70 @@ join_test(Config) ->
 
     libp2p_swarm:stop(Swarm0),
     libp2p_swarm:stop(Swarm1),
+    ok.
+
+us915_join_cf_list_test(Config) ->
+    AppKey = proplists:get_value(app_key, Config),
+    HotspotDir = proplists:get_value(base_dir, Config) ++ "/join_cf_list_test",
+    filelib:ensure_dir(HotspotDir),
+    RouterSwarm = blockchain_swarm:swarm(),
+    [Address | _] = libp2p_swarm:listen_addrs(RouterSwarm),
+    {Swarm, _} = test_utils:start_swarm(HotspotDir, no_this_is_patrick, 0),
+    PubKeyBin = libp2p_swarm:pubkey_bin(Swarm),
+
+    {ok, Stream} = libp2p_swarm:dial_framed_stream(
+        Swarm,
+        Address,
+        router_handler_test:version(),
+        router_handler_test,
+        [self(), PubKeyBin]
+    ),
+
+    %% Send join packet
+    DevNonce1 = crypto:strong_rand_bytes(2),
+    Stream ! {send, test_utils:join_packet(PubKeyBin, AppKey, DevNonce1, -100)},
+    timer:sleep(router_utils:join_timeout()),
+
+    %% Waiting for reply resp form router
+    {_NetID1, _DevAddr1, _DLSettings1, _RxDelay1, _NwkSKey1, _AppSKey1, CFList1} = test_utils:wait_for_join_resp(
+        PubKeyBin,
+        AppKey,
+        DevNonce1
+    ),
+    %% CFList should not be empty.
+    %% Has a channel mask setup
+    ?assertNotEqual(<<>>, CFList1),
+
+    %% Send another join to get a different cflist
+    DevNonce2 = crypto:strong_rand_bytes(2),
+    Stream ! {send, test_utils:join_packet(PubKeyBin, AppKey, DevNonce2, -100)},
+    timer:sleep(router_utils:join_timeout()),
+
+    {_NetID2, _DevAddr2, _DLSettings2, _RxDelay2, _NwkSKey2, _AppSKey2, CFList2} = test_utils:wait_for_join_resp(
+        PubKeyBin,
+        AppKey,
+        DevNonce2
+    ),
+    %% This CFList is empty. We don't know if the device is using lora version
+    %% older than 1.0.3 and might be choking on the cflist, so we'll send an
+    %% empty one and see if they can join with that. The device will still
+    %% receive a channel mask update in the first packets downlink after join.
+    ?assertEqual(<<>>, CFList2),
+
+    %% Send one more just to make sure it wasn't a fluke
+    DevNonce3 = crypto:strong_rand_bytes(2),
+    Stream ! {send, test_utils:join_packet(PubKeyBin, AppKey, DevNonce3, -100)},
+    timer:sleep(router_utils:join_timeout()),
+
+    {_NetID3, _DevAddr3, _DLSettings3, _RxDelay3, _NwkSKey3, _AppSKey3, CFList3} = test_utils:wait_for_join_resp(
+        PubKeyBin,
+        AppKey,
+        DevNonce3
+    ),
+    %% We alternate sending and not sending the channel mask cflist.
+    ?assertNotEqual(<<>>, CFList3),
+
+    libp2p_swarm:stop(Swarm),
     ok.
 
 adr_test(Config) ->

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -863,10 +863,17 @@ us915_join_cf_list_test(Config) ->
         PubKeyBin,
         AppSKey3
     ),
-    ?assertEqual(
-        true,
-        lists:keymember(link_adr_req, 1, Reply#frame.fopts),
-        "Downlink should contain link_adr_req"
+
+    <<CFListChannelMask:16/integer, _/binary>> = CFList3,
+    ?assertMatch(
+        [
+            %% LinkADRReq shape:
+            %% {link_adr_req, DataRate, TXPower, ChMask, ChMaskCntl, NbTrans}
+            {link_adr_req, _, _, _NoActiveChannels = 0, _All125kHzOFF = 7, _},
+            {link_adr_req, _, _, CFListChannelMask, _ApplyChannels0to15 = 0, _}
+        ],
+        proplists:lookup_all(link_adr_req, Reply#frame.fopts),
+        "Downlink turns on same channels as join cflist"
     ),
 
     libp2p_swarm:stop(Swarm),

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -197,7 +197,7 @@ lw_join_test(Config) ->
         AppKey,
         DevNonce
     ),
-    ?assertEqual(CFList, lorawan_mac_region:mk_join_accept_cf_list(Region)),
+    ?assertEqual(CFList, lorawan_mac_region:mk_join_accept_cf_list(Region, _FirstJoinAttempt = 0)),
 
     %% Check that device is in cache now
     {ok, DB, [_, CF]} = router_db:get(),

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -16,7 +16,10 @@
     wait_for_console_event_sub/2,
     wait_for_join_resp/3,
     wait_channel_data/1,
-    wait_state_channel_message/1, wait_state_channel_message/2, wait_state_channel_message/8,
+    wait_state_channel_message/1,
+    wait_state_channel_message/2,
+    wait_state_channel_message/3,
+    wait_state_channel_message/8,
     wait_organizations_burned/1,
     join_payload/2,
     join_packet/3, join_packet/4,
@@ -511,6 +514,46 @@ wait_state_channel_message(Timeout, PubKeyBin) ->
         _Class:_Reason:_Stacktrace ->
             ct:pal("wait_state_channel_message stacktrace ~p~n", [{_Reason, _Stacktrace}]),
             ct:fail("wait_state_channel_message failed")
+    end.
+
+wait_state_channel_message(Timeout, PubKeyBin, AppSKey) ->
+    try
+        receive
+            {client_data, PubKeyBin, Data} ->
+                try
+                    blockchain_state_channel_v1_pb:decode_msg(
+                        Data,
+                        blockchain_state_channel_message_v1_pb
+                    )
+                of
+                    #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
+                        case Resp of
+                            #blockchain_state_channel_response_v1_pb{
+                                accepted = true,
+                                downlink = undefined
+                            } ->
+                                wait_state_channel_message(Timeout, PubKeyBin, AppSKey);
+                            #blockchain_state_channel_response_v1_pb{
+                                accepted = true,
+                                downlink = Packet
+                            } ->
+                                {ok, deframe_packet(Packet, AppSKey)}
+                        end;
+                    _Else ->
+                        ct:fail("wait_state_channel_message with frame wrong message ~p ", [_Else])
+                catch
+                    _E:_R ->
+                        ct:fail("wait_state_channel_message with frame failed to decode ~p ~p", [
+                            Data,
+                            {_E, _R}
+                        ])
+                end
+        after Timeout -> ct:fail("wait_state_channel_message with frame timeout")
+        end
+    catch
+        _Class:_Reason:_Stacktrace ->
+            ct:pal("wait_state_channel_message with frame stacktrace ~p~n", [{_Reason, _Stacktrace}]),
+            ct:fail("wait_state_channel_message with frame failed")
     end.
 
 wait_state_channel_message(Msg, Device, FrameData, Type, FPending, Ack, Fport, FCnt) ->

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -275,7 +275,7 @@ get_device_channels_worker(DeviceID) ->
     {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
     {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
         _OUI, ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADREngine,
-        _IsActive} = sys:get_state(
+        _IsActive, _JoinAttemptCount} = sys:get_state(
         WorkerPid
     ),
     ChannelsWorkerPid.
@@ -284,7 +284,7 @@ get_last_dev_nonce(DeviceID) ->
     {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
     {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
         _OUI, _ChannelsWorkerPid, LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
-        _IsActive} = sys:get_state(
+        _IsActive, _JoinAttemptCount} = sys:get_state(
         WorkerPid
     ),
     LastDevNonce.
@@ -299,7 +299,7 @@ get_device_last_seen_fcnt(DeviceID) ->
     {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
     {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, FCnt,
         _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
-        _IsActive} = sys:get_state(
+        _IsActive, _JoinAttemptCount} = sys:get_state(
         WorkerPid
     ),
     FCnt.
@@ -308,7 +308,7 @@ get_device_worker_device(DeviceID) ->
     {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
     {state, _Chain, _DB, _CF, _FrameTimeout, Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
         _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
-        _IsActive} = sys:get_state(
+        _IsActive, _JoinAttemptCount} = sys:get_state(
         WorkerPid
     ),
     Device.
@@ -317,7 +317,7 @@ get_device_worker_offer_cache(DeviceID) ->
     {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
     {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
         _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, OfferCache, _ADRCache,
-        _IsActive} = sys:get_state(
+        _IsActive, _JoinAttemptCount} = sys:get_state(
         WorkerPid
     ),
     OfferCache.


### PR DESCRIPTION
newer lora spec supports an optional channel mask in the cflist for
us915 devices. older specs say devices should ignore non-empty cflists,
but real world testing proved this to be a lie.

We are going to alternate filling the cflist with channel mask
information to give each device a chance to join without having to
register what version devices they are in console. They will still get
channel mask updates in the first packet after a successful join. This
will allow newer devices to be a little smarter.

Count join attempts in device worker. Allows for the alternating
cflists, also something we can potentially look at to see who's having
trouble joining.