### PR TITLE
Update EU868 donwlink strength

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -884,7 +884,7 @@ handle_info(
     Rx2 = join2_from_packet(Region, Packet),
     DownlinkPacket = blockchain_helium_packet_v1:new_downlink(
         craft_join_reply(JoinAcceptArgs, JoinAttemptCount),
-        lorawan_mac_region:downlink_signal_strength(Region),
+        lorawan_mac_region:downlink_signal_strength(Region, TxFreq),
         TxTime,
         TxFreq,
         binary_to_list(TxDataRate),
@@ -1597,7 +1597,7 @@ handle_frame_timeout(
             Rx2 = rx2_from_packet(Region, Packet0),
             Packet1 = blockchain_helium_packet_v1:new_downlink(
                 Reply,
-                lorawan_mac_region:downlink_signal_strength(Region),
+                lorawan_mac_region:downlink_signal_strength(Region, TxFreq),
                 adjust_rx_time(TxTime),
                 TxFreq,
                 binary_to_list(TxDataRate),
@@ -1695,7 +1695,7 @@ handle_frame_timeout(
     Rx2 = rx2_from_packet(Region, Packet0),
     Packet1 = blockchain_helium_packet_v1:new_downlink(
         Reply,
-        lorawan_mac_region:downlink_signal_strength(Region),
+        lorawan_mac_region:downlink_signal_strength(Region, TxFreq),
         adjust_rx_time(TxTime),
         TxFreq,
         binary_to_list(TxDataRate),

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -29,7 +29,7 @@
 -export([max_uplink_snr/1]).
 -export([tx_time/2, tx_time/3]).
 
--export([downlink_signal_strength/1]).
+-export([downlink_signal_strength/2]).
 -export([dr_to_down/3]).
 -export([window2_dr/1, top_level_region/1, f2uch/2]).
 -export([mk_join_accept_cf_list/2]).
@@ -686,15 +686,18 @@ uplink_power_table_('EU868') ->
 %% Bobcat team was testing and noticed downlink `rf_power' was too high for CN470.
 %%
 %% longAP team was testing and also noticed `rf_power' was too high for EU868.
-%% Max for EU868 is uplink power index 0.
+%% Followup from disk91:
+%% https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf (page 22)
+%% MwToDb = fun(Mw) -> round(10 * math:log10(Mw)) end.
 %%
 %% NOTE: We may want to reduce to default tx_power
 %% @end
 %% ------------------------------------------------------------------
--spec downlink_signal_strength(atom()) -> non_neg_integer().
-downlink_signal_strength('CN470') -> 16;
-downlink_signal_strength('EU868') -> 20;
-downlink_signal_strength(_Region) -> ?DEFAULT_DOWNLINK_TX_POWER.
+-spec downlink_signal_strength(atom(), freq_whole()) -> non_neg_integer().
+downlink_signal_strength('CN470', _Freq) -> 16;
+downlink_signal_strength('EU868', Freq) when 869.4 =< Freq andalso Freq < 869.65 -> 27;
+downlink_signal_strength('EU868', _Freq) -> 14;
+downlink_signal_strength(_Region, _Freq) -> ?DEFAULT_DOWNLINK_TX_POWER.
 
 %% static channel plan parameters
 freq('EU868') ->

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -232,7 +232,7 @@ lw_join_test(Config) ->
     end,
 
     %% Waiting for data from HTTP channel
-    test_utils:wait_channel_data(#{
+    {ok, #{<<"hotspots">> := [#{<<"frequency">> := Frequency}]}} = test_utils:wait_channel_data(#{
         <<"uuid">> => fun erlang:is_binary/1,
         <<"id">> => ?CONSOLE_DEVICE_ID,
         <<"name">> => ?CONSOLE_DEVICE_NAME,
@@ -287,7 +287,7 @@ lw_join_test(Config) ->
             <<"hotspot">> => #{
                 <<"id">> => erlang:list_to_binary(libp2p_crypto:bin_to_b58(PubKeyBin0)),
                 <<"name">> => erlang:list_to_binary(HotspotName0),
-                <<"rssi">> => lorawan_mac_region:downlink_signal_strength(Region),
+                <<"rssi">> => lorawan_mac_region:downlink_signal_strength(Region, Frequency),
                 <<"snr">> => 0.0,
                 <<"spreading">> => fun erlang:is_binary/1,
                 <<"frequency">> => fun erlang:is_float/1,
@@ -529,7 +529,7 @@ lw_join_test(Config) ->
             <<"hotspot">> => #{
                 <<"id">> => erlang:list_to_binary(libp2p_crypto:bin_to_b58(PubKeyBin0)),
                 <<"name">> => erlang:list_to_binary(HotspotName0),
-                <<"rssi">> => lorawan_mac_region:downlink_signal_strength(Region),
+                <<"rssi">> => lorawan_mac_region:downlink_signal_strength(Region, Frequency),
                 <<"snr">> => '_',
                 <<"spreading">> => fun erlang:is_binary/1,
                 <<"frequency">> => fun erlang:is_float/1,


### PR DESCRIPTION
Closer match the guidelines in the country.
There's a small frequency range where they're allowed full power.
Otherwise default to 14.