### PR TITLE
bump chatterbox, pull in fix to silence invalid preface errors msgs

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.1">>},1},
  {<<"chatterbox">>,
   {git,"https://github.com/andymck/chatterbox",
-       {ref,"62515d582e590edba211b0e9adda78febbb75092"}},
+       {ref,"b56a2a08b8a31b7ab0d536e5e8a55d5abe70390f"}},
   1},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
Silences the invalid_preface error when a non http2 client hits the grpc port 8080. 

Chatterbox commit: https://github.com/andymck/chatterbox/commit/b56a2a08b8a31b7ab0d536e5e8a55d5abe70390f

This is already deployed on various validators.