### PR TITLE
Add buffer calc to sc expiration

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -15,6 +15,11 @@ ROUTER_SC_OPEN_DC_AMOUNT=2000
 # Current min: 15 blocks, max abbout 5000 blocks
 ROUTER_SC_EXPIRATION_INTERVAL=120
 
+# State Channel Expiration Buffer
+# Minimum distance state channels can expire within another expiration
+# default: 15 when not set
+ROUTER_SC_EXPIRATION_BUFFER=15
+
 # Console's connection info (see https://github.com/helium/console)
 ROUTER_CONSOLE_ENDPOINT=http://helium_console:4000
 ROUTER_CONSOLE_WS_ENDPOINT=ws://helium_console:4000/socket/router/websocket

--- a/config/sys.config
+++ b/config/sys.config
@@ -24,6 +24,7 @@
         {oui, 1},
         {sc_open_dc_amount, 100000000},
         {sc_expiration_interval, 25},
+        {sc_expiration_buffer, 15},
         {router_console_api, [
             {endpoint, <<"https://console.helium.com">>},
             {ws_endpoint, <<"wss://console.helium.com/socket/router/websocket">>},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -17,7 +17,8 @@
         {max_inbound_connections, 12},
         {outbound_gossip_connections, 4},
         {sc_packet_handler, router_device_routing},
-        {sc_max_actors, "${ROUTER_SC_MAX_ACTORS}"}
+        {sc_max_actors, "${ROUTER_SC_MAX_ACTORS}"},
+        {sc_expiration_buffer, "${ROUTER_SC_EXPIRATION_BUFFER}"}
     ]},
     {router, [
         {max_v8_context, 1000},


### PR DESCRIPTION
While putting this on a server I'd like to lower the current expiration interval so if things start to run away, its in a more recoverable way.

Router attempts to always have at least 1 safety valve state channel
open. That paired with the expiration calculation lets us get in a
position where we have more than one state channel that closes within a
few blocks of each other.

It appears this is causing latency spikes when multiple channels are
closed close together. This is an attempt to have some minimum amount of
time between closes to prevent bursts of packets that have been waiting
to get into a state channel.

note: exhausted state channels can not close, they have to wait for
their expiry time.

It might be a good idea to brainstorm a different way to think about
state channel expirations, router is no longer in the position where its
bouncing back and forth between two channels, and the purpose of the
second was the be an immediate overflow when the first needs to close.

There are cases where many more state channels are opened because they
max out actors. Depending on who makes it into which state channels, the
rate at which each channel drains is not something we currently track or
compensate for.