### PR TITLE
Potential crash when sending events to console

### DIFF
--- a/src/device/router_device_channels_worker.erl
+++ b/src/device/router_device_channels_worker.erl
@@ -735,7 +735,7 @@ format_hotspot(
         snr => blockchain_helium_packet_v1:snr(Packet),
         spreading => erlang:list_to_binary(blockchain_helium_packet_v1:datarate(Packet)),
         frequency => Freq,
-        channel => lorawan_mac_region:f2uch(Region, Freq),
+        channel => lorawan_mac_region:freq_to_chan(Region, Freq),
         lat => Lat,
         long => Long,
         hold_time => HoldTime

--- a/src/router_utils.erl
+++ b/src/router_utils.erl
@@ -769,7 +769,7 @@ format_hotspot(Chain, PubKeyBin, Packet, Region) ->
         snr => blockchain_helium_packet_v1:snr(Packet),
         spreading => erlang:list_to_binary(blockchain_helium_packet_v1:datarate(Packet)),
         frequency => Freq,
-        channel => lorawan_mac_region:f2uch(Region, Freq),
+        channel => lorawan_mac_region:freq_to_chan(Region, Freq),
         lat => Lat,
         long => Long
     }.


### PR DESCRIPTION
When asking for a channel we assume all frequencies in events going to
console are uplink frequencies. Most of the  time this is okay because
uplinks and downlinks follow more or less the same line. That's not the
case for all regions.

If we can't get a channel assuming an uplink frequency, try assuming
it's a downlink frequency, otherwise we have a good failure on our
hands.

fixes #379