### PR TITLE
cache device for packet hash at first sight

### DIFF
--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -1001,6 +1001,7 @@ force_evict(PHash) ->
 ) -> {ok, router_device:device()} | {error, any()}.
 get_device_for_offer(Offer, DevAddr, PubKeyBin, Chain) ->
     PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
+    %% interrogate the cache without inserting value
     case e2qc_nif:get(?PHASH_TO_DEVICE_CACHE, PHash) of
         notfound ->
             case get_and_sort_devices(DevAddr, PubKeyBin, Chain) of

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -21,17 +21,33 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+%% sc_handler API
 -export([
     init/0,
     handle_offer/2,
     handle_packet/3,
-    handle_packet/4,
+    handle_packet/4
+]).
+
+%% multi-buy API
+-export([
     deny_more/1,
     accept_more/1,
     accept_more/2,
-    clear_multi_buy/1,
+    clear_multi_buy/1
+]).
+
+%% replay API
+-export([
     allow_replay/3,
     clear_replay/1
+]).
+
+%% Cache API
+-export([
+    get_device_for_offer/4,
+    cache_device_for_hash/2,
+    force_evict/1
 ]).
 
 %% biggest unsigned number in 23 bits
@@ -79,6 +95,13 @@
 -define(DEVADDR_NOT_IN_SUBNET, devaddr_not_in_subnet).
 -define(OUI_UNKNOWN, oui_unknown).
 -define(DEVADDR_NO_DEVICE, devaddr_no_device).
+
+%% Packet hash cache
+-define(PHASH_TO_DEVICE_CACHE, phash_to_device_cache).
+-define(PHASH_TO_DEVICE_CACHE_MAXSIZE, 4 * 1024 * 1024).
+-define(PHASH_TO_DEVICE_CACHE_MINSIZE, round(0.3 * ?PHASH_TO_DEVICE_CACHE_MAXSIZE)).
+%% e2qc lifetime is in seconds
+-define(PHASH_TO_DEVICE_CACHE_LIFETIME, 1).
 
 %% Join offer rejected reasons
 -define(CONSOLE_UNKNOWN_DEVICE, console_unknown_device).
@@ -497,10 +520,10 @@ validate_packet_offer(Offer, _Pid, Chain) ->
         ok ->
             PubKeyBin = blockchain_state_channel_offer_v1:hotspot(Offer),
             DevAddr1 = lorawan_utils:reverse(devaddr_to_bin(DevAddr0)),
-            case get_and_sort_devices(DevAddr1, PubKeyBin, Chain) of
-                [] ->
-                    {error, ?DEVADDR_NO_DEVICE};
-                [Device | _] ->
+            case get_device_for_offer(Offer, DevAddr1, PubKeyBin, Chain) of
+                {error, _} = Err ->
+                    Err;
+                {ok, Device} ->
                     case check_device_is_active(Device, PubKeyBin) of
                         {error, _Reason} = Error ->
                             Error;
@@ -942,6 +965,61 @@ find_device(PubKeyBin, DevAddr, MIC, Payload, Chain) ->
             {error, {unknown_device, DevAddr}};
         {Device, NwkSKey} ->
             {Device, NwkSKey}
+    end.
+
+%%%-------------------------------------------------------------------
+%% @doc
+%% If there are devaddr collisions, we don't know the correct device until we
+%% get the whole packet with the payload. Once we have that, the device can tell
+%% routing the a packet hash belongs to it. That reservation will only last a
+%% short while. But it might be enough to have subsequent offers lookup the
+%% correct device by the time they come through.
+%% @end
+%%%-------------------------------------------------------------------
+-spec cache_device_for_hash(PHash :: binary(), Device :: router_device:device()) -> ok.
+cache_device_for_hash(PHash, Device) ->
+    ok = e2qc_nif:put(
+        ?PHASH_TO_DEVICE_CACHE,
+        PHash,
+        erlang:term_to_binary(Device),
+        ?PHASH_TO_DEVICE_CACHE_MAXSIZE,
+        ?PHASH_TO_DEVICE_CACHE_MINSIZE,
+        ?PHASH_TO_DEVICE_CACHE_LIFETIME
+    ),
+    ok.
+
+-spec force_evict(PHash :: binary()) -> ok.
+force_evict(PHash) ->
+    _ = e2qc_nif:destroy(?PHASH_TO_DEVICE_CACHE, PHash),
+    ok.
+
+-spec get_device_for_offer(
+    Offer :: blockchain_state_channel_offer_v1:offer(),
+    DevAddr :: binary(),
+    PubKeyBin :: libp2p_crypto:pubkey_bin(),
+    Chain :: blockchain:blockchain()
+) -> {ok, router_device:device()} | {error, any()}.
+get_device_for_offer(Offer, DevAddr, PubKeyBin, Chain) ->
+    PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
+    case e2qc_nif:get(?PHASH_TO_DEVICE_CACHE, PHash) of
+        notfound ->
+            case get_and_sort_devices(DevAddr, PubKeyBin, Chain) of
+                [] ->
+                    {error, ?DEVADDR_NO_DEVICE};
+                [Device | _] ->
+                    lager:debug(
+                        "best guess device for offer [hash: ~p] [device_id: ~p] [pubkeybin: ~p]",
+                        [PHash, router_device:id(Device), PubKeyBin]
+                    ),
+                    {ok, Device}
+            end;
+        D ->
+            Device = erlang:binary_to_term(D),
+            lager:debug(
+                "cached device for offer [hash: ~p] [device_id: ~p] [pubkeybin: ~p]",
+                [PHash, router_device:id(Device), PubKeyBin]
+            ),
+            {ok, Device}
     end.
 
 -spec get_and_sort_devices(

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -101,7 +101,8 @@
 -define(PHASH_TO_DEVICE_CACHE_MAXSIZE, 4 * 1024 * 1024).
 -define(PHASH_TO_DEVICE_CACHE_MINSIZE, round(0.3 * ?PHASH_TO_DEVICE_CACHE_MAXSIZE)).
 %% e2qc lifetime is in seconds
--define(PHASH_TO_DEVICE_CACHE_LIFETIME, 1).
+%% (?RX2WINDOW + 1) to give a better chance for late packets
+-define(PHASH_TO_DEVICE_CACHE_LIFETIME, 3).
 
 %% Join offer rejected reasons
 -define(CONSOLE_UNKNOWN_DEVICE, console_unknown_device).

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -47,7 +47,7 @@
 -export([
     get_device_for_offer/4,
     cache_device_for_hash/2,
-    force_evict/1
+    force_evict_packet_hash/1
 ]).
 
 %% biggest unsigned number in 23 bits
@@ -988,8 +988,8 @@ cache_device_for_hash(PHash, Device) ->
     ),
     ok.
 
--spec force_evict(PHash :: binary()) -> ok.
-force_evict(PHash) ->
+-spec force_evict_packet_hash(PHash :: binary()) -> ok.
+force_evict_packet_hash(PHash) ->
     _ = e2qc_nif:destroy(?PHASH_TO_DEVICE_CACHE, PHash),
     ok.
 

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -981,7 +981,7 @@ cache_device_for_hash(PHash, Device) ->
     ok = e2qc_nif:put(
         ?PHASH_TO_DEVICE_CACHE,
         PHash,
-        erlang:term_to_binary(Device),
+        router_device:serialize(Device),
         ?PHASH_TO_DEVICE_CACHE_MAXSIZE,
         ?PHASH_TO_DEVICE_CACHE_MINSIZE,
         ?PHASH_TO_DEVICE_CACHE_LIFETIME
@@ -1015,7 +1015,7 @@ get_device_for_offer(Offer, DevAddr, PubKeyBin, Chain) ->
                     {ok, Device}
             end;
         D ->
-            Device = erlang:binary_to_term(D),
+            Device = router_device:deserialize(D),
             lager:debug(
                 "cached device for offer [hash: ~p] [device_id: ~p] [pubkeybin: ~p]",
                 [PHash, router_device:id(Device), PubKeyBin]

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -641,6 +641,7 @@ handle_cast(
             false -> packet
         end,
     PHash = blockchain_helium_packet_v1:packet_hash(Packet0),
+    router_device_routing:cache_device_for_hash(PHash, Device0),
     lager:debug("got packet (~p) ~p from ~p", [
         PHash,
         lager:pr(Packet0, blockchain_helium_packet_v1),

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -142,7 +142,7 @@ packet_hash_cache_test(Config) ->
     ),
 
     %% go back to nothing
-    router_device_routing:force_evict(PHash),
+    router_device_routing:force_evict_packet_hash(PHash),
 
     %% back to being wrong, and it feels so right
     ?assertNotEqual(

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -8,7 +8,8 @@
 
 -export([
     bad_fcnt_test/1,
-    multi_buy_test/1
+    multi_buy_test/1,
+    packet_hash_cache_test/1
 ]).
 
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
@@ -37,7 +38,8 @@
 all() ->
     [
         bad_fcnt_test,
-        multi_buy_test
+        multi_buy_test,
+        packet_hash_cache_test
     ].
 
 %%--------------------------------------------------------------------
@@ -55,6 +57,104 @@ end_per_testcase(TestCase, Config) ->
 %%--------------------------------------------------------------------
 %% TEST CASES
 %%--------------------------------------------------------------------
+
+packet_hash_cache_test(Config) ->
+    %% -------------------------------------------------------------------
+    %% Hotspots
+    #{public := PubKey0} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin0 = libp2p_crypto:pubkey_to_bin(PubKey0),
+    {ok, _HotspotName0} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(PubKeyBin0)),
+
+    #{public := PubKey1} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin1 = libp2p_crypto:pubkey_to_bin(PubKey1),
+    {ok, _HotspotName1} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(PubKeyBin1)),
+
+    %% -------------------------------------------------------------------
+    %% Device
+    #{} = test_utils:join_device(Config),
+    {ok, DB, [_, CF]} = router_db:get(),
+    WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
+    {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
+
+    %% Change name of devices
+    Device1 = router_device:update([{name, <<"new-name-1">>}], Device0),
+    Device2 = router_device:update([{name, <<"new-name-2">>}], Device1),
+    {ok, _} = router_device_cache:save(Device1),
+    %% NOTE: purposefully not putting device-2 in the cache
+    %% {ok, Device2} = router_device_cache:save(Device2),
+
+    ?assertEqual(
+        router_device:devaddr(Device0),
+        router_device:devaddr(Device1),
+        "all devices have same devaddr"
+    ),
+    ?assertEqual(
+        router_device:devaddr(Device1),
+        router_device:devaddr(Device2),
+        "all devices have same devaddr"
+    ),
+
+    %% -------------------------------------------------------------------
+    %% "make me an offer I cannot refuse" - Sufjan Stevens (right?)
+    NwkSessionKey = router_device:nwk_s_key(Device2),
+    AppSessionKey = router_device:app_s_key(Device2),
+    SCPacket = test_utils:frame_packet(
+        ?UNCONFIRMED_UP,
+        PubKeyBin0,
+        NwkSessionKey,
+        AppSessionKey,
+        0,
+        #{dont_encode => true, routing => true}
+    ),
+    Offer = blockchain_state_channel_offer_v1:from_packet(
+        blockchain_state_channel_packet_v1:packet(SCPacket),
+        blockchain_state_channel_packet_v1:hotspot(SCPacket),
+        blockchain_state_channel_packet_v1:region(SCPacket)
+    ),
+    PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
+
+    %% -------------------------------------------------------------------
+    %% Query for devices
+    Chain = blockchain_worker:blockchain(),
+    DevAddr = router_device:devaddr(Device1),
+
+    %% make sure things go wrong first
+    ?assertNotEqual(
+        {ok, Device2},
+        router_device_routing:get_device_for_offer(Offer, DevAddr, PubKeyBin0, Chain)
+    ),
+    ?assertNotEqual(
+        {ok, Device2},
+        router_device_routing:get_device_for_offer(Offer, DevAddr, PubKeyBin1, Chain)
+    ),
+
+    %% make it better
+    router_device_routing:cache_device_for_hash(PHash, Device2),
+
+    %% now we should go right
+    ?assertEqual(
+        {ok, Device2},
+        router_device_routing:get_device_for_offer(Offer, DevAddr, PubKeyBin0, Chain)
+    ),
+    ?assertEqual(
+        {ok, Device2},
+        router_device_routing:get_device_for_offer(Offer, DevAddr, PubKeyBin1, Chain)
+    ),
+
+    %% go back to nothing
+    router_device_routing:force_evict(PHash),
+
+    %% back to being wrong, and it feels so right
+    ?assertNotEqual(
+        {ok, Device2},
+        router_device_routing:get_device_for_offer(Offer, DevAddr, PubKeyBin0, Chain)
+    ),
+    ?assertNotEqual(
+        {ok, Device2},
+        router_device_routing:get_device_for_offer(Offer, DevAddr, PubKeyBin1, Chain)
+    ),
+
+    ok.
 
 multi_buy_test(Config) ->
     AppKey = proplists:get_value(app_key, Config),


### PR DESCRIPTION
When a first packet comes through, a device will cache itself to the
hash for a second. This should help subsequent packets come through
being purchased using the correct devices information.

Devices will re-up the cache for every packet they see, eviction time
automatically happens after 1 second.

multi-buy work tries to wait until the first packet has crossed the line before deciding to buy more.
https://github.com/helium/router/blob/master/src/device/router_device_routing.erl#L204-L206