### PR TITLE
remove default devaddr

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -4,9 +4,6 @@ ROUTER_SEED_NODES=/ip4/35.166.211.46/tcp/2154,/ip4/44.236.95.167/tcp/2154
 # OUI used by router (see https://developer.helium.com/blockchain/blockchain-cli#oui)
 ROUTER_OUI=999
 
-# Default devaddr if we fail to allocate one
-ROUTER_DEFAULT_DEVADDR=AAQASA==
-
 # State Channel Open amount
 ROUTER_SC_OPEN_DC_AMOUNT=2000
 

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -22,7 +22,6 @@
     {router, [
         {max_v8_context, 1000},
         {oui, "${ROUTER_OUI}"},
-        {default_devaddr, "${ROUTER_DEFAULT_DEVADDR}"},
         {sc_open_dc_amount, "${ROUTER_SC_OPEN_DC_AMOUNT}"},
         {sc_expiration_interval, "${ROUTER_SC_EXPIRATION_INTERVAL}"},
         {sc_expiration_buffer, "${ROUTER_SC_EXPIRATION_BUFFER}"},

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -21,7 +21,6 @@
 %% ------------------------------------------------------------------
 -export([
     start_link/1,
-    default_devaddr/0,
     allocate/2,
     sort_devices/3,
     pubkeybin_to_loc/2,
@@ -57,21 +56,6 @@
 %% ------------------------------------------------------------------
 start_link(Args) ->
     gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []).
-
--spec default_devaddr() -> binary().
-default_devaddr() ->
-    DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
-    DefaultDevaddr = <<33554431:25/integer-unsigned-little, DevAddrPrefix:7/integer>>,
-    case application:get_env(router, default_devaddr) of
-        undefined ->
-            DefaultDevaddr;
-        {ok, Base64Str} ->
-            try base64:decode(Base64Str) of
-                Decoded -> Decoded
-            catch
-                _:_ -> DefaultDevaddr
-            end
-    end.
 
 -spec allocate(router_device:device(), libp2p_crypto:pubkey_bin()) ->
     {ok, binary()} | {error, any()}.

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -283,17 +283,7 @@ handle_call(
         AppKey,
         lorawan_utils:padded(16, <<16#02, AppNonce/binary, ?NET_ID/binary, DevNonce/binary>>)
     ),
-    DevAddr =
-        case router_device_devaddr:allocate(Device0, PubKeyBin) of
-            {ok, D} ->
-                D;
-            {error, _Reason} ->
-                lager:warning("failed to allocate devaddr for ~p: ~p", [
-                    router_device:id(Device0),
-                    _Reason
-                ]),
-                router_device_devaddr:default_devaddr()
-        end,
+    {ok, DevAddr} = router_device_devaddr:allocate(Device0, PubKeyBin),
     DeviceUpdates = [
         {keys, [{NwkSKey, AppSKey}]},
         {devaddr, DevAddr},
@@ -1203,17 +1193,7 @@ handle_join(
         AppKey,
         lorawan_utils:padded(16, <<16#02, AppNonce/binary, ?NET_ID/binary, DevNonce/binary>>)
     ),
-    DevAddr =
-        case router_device_devaddr:allocate(Device0, PubKeyBin) of
-            {ok, D} ->
-                D;
-            {error, _Reason} ->
-                lager:warning("failed to allocate devaddr for ~p: ~p", [
-                    router_device:id(Device0),
-                    _Reason
-                ]),
-                router_device_devaddr:default_devaddr()
-        end,
+    {ok, DevAddr} = router_device_devaddr:allocate(Device0, PubKeyBin),
     DeviceName = router_device:name(APIDevice),
     %% don't set the join nonce here yet as we have not chosen the best join request yet
     {AppEUI, DevEUI} = {lorawan_utils:reverse(AppEUI0), lorawan_utils:reverse(DevEUI0)},

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -50,6 +50,8 @@ end_per_testcase(TestCase, Config) ->
 %%--------------------------------------------------------------------
 
 allocate(Config) ->
+    meck:delete(router_device_devaddr, allocate, 2, false),
+
     Swarm = proplists:get_value(swarm, Config),
     Keys = proplists:get_value(keys, Config),
     PubKeyBin = libp2p_swarm:pubkey_bin(Swarm),
@@ -102,6 +104,8 @@ allocate(Config) ->
     ok.
 
 route_packet(Config) ->
+    meck:delete(router_device_devaddr, allocate, 2, false),
+
     Swarm = proplists:get_value(swarm, Config),
     Keys = proplists:get_value(keys, Config),
     PubKeyBin = libp2p_swarm:pubkey_bin(Swarm),

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -150,7 +150,6 @@ route_packet(Config) ->
     DevAddr = router_device:devaddr(Device0),
 
     ?assert(DevAddr =/= undefined),
-    ?assert(DevAddr =/= router_device_devaddr:default_devaddr()),
 
     Stream !
         {send,

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -157,6 +157,8 @@ packet_hash_cache_test(Config) ->
     ok.
 
 multi_buy_test(Config) ->
+    meck:delete(router_device_devaddr, allocate, 2, false),
+
     AppKey = proplists:get_value(app_key, Config),
     Swarm = proplists:get_value(swarm, Config),
     Keys = proplists:get_value(keys, Config),

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -67,6 +67,11 @@ end_per_group(_, _) ->
     ok.
 
 init_per_testcase(TestCase, Config) ->
+    meck:new(router_device_devaddr, [passthrough]),
+    meck:expect(router_device_devaddr, allocate, fun(_, _) ->
+        DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+        {ok, <<33554431:25/integer-unsigned-little, DevAddrPrefix:7/integer>>}
+    end),
     BaseDir =
         erlang:atom_to_list(TestCase) ++
             "-" ++ erlang:atom_to_list(proplists:get_value(region, Config)),
@@ -124,6 +129,7 @@ end_per_testcase(_TestCase, Config) ->
     Tab = proplists:get_value(ets, Config),
     ets:delete(Tab),
     catch exit(whereis(libp2p_swarm_sup_join_test_swarm_0), kill),
+    meck:unload(router_device_devaddr),
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
The scenario where we potentially return an error and fallback to
default_devaddr was removed quite a while ago, and having the default
devaddr in settings causes confusion.

re: https://github.com/helium/router/issues/413