### PR TITLE
Remove devices that don't exist when posting events

### DIFF
--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -402,6 +402,12 @@ event(Device, Map) ->
                 {ok, 200, _Headers, _Body} ->
                     End = erlang:system_time(millisecond),
                     ok = router_metrics:console_api_observe(report_status, ok, End - Start);
+                {ok, 404, _ResponseHeaders, _ResposnseBody} ->
+                    {ok, DB, CF} = router_db:get_devices(),
+                    ok = router_device:delete(DB, CF, DeviceID),
+                    ok = router_device_cache:delete(DeviceID),
+                    lager:info("device was removed, removing from DB and cache"),
+                    ok;
                 _Other ->
                     lager:warning("got non 200 resp ~p", [_Other]),
                     End = erlang:system_time(millisecond),

--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -480,7 +480,7 @@ init(Args) ->
     Secret = maps:get(secret, Args),
     Token = get_token(Endpoint, Secret),
     ok = token_insert(Endpoint, DownlinkEndpoint, Token),
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     _ = erlang:send_after(?TOKEN_CACHE_TIME, self(), refresh_token),
     {ok, P} = load_pending_burns(DB),
     Inflight = maybe_spawn_pending_burns(P, []),

--- a/src/apis/router_console_ws_worker.erl
+++ b/src/apis/router_console_ws_worker.erl
@@ -52,7 +52,7 @@ init(Args) ->
     WSEndpoint = maps:get(ws_endpoint, Args),
     Token = router_console_api:get_token(),
     WSPid = start_ws(WSEndpoint, Token),
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     {ok, #state{
         ws = WSPid,
         ws_endpoint = WSEndpoint,

--- a/src/router_db.erl
+++ b/src/router_db.erl
@@ -13,7 +13,8 @@
 -export([
     start_link/1,
     get/0,
-    get_xor_filter_devices/0
+    get_xor_filter_devices/0,
+    get_devices/0
 ]).
 
 %% ------------------------------------------------------------------
@@ -51,6 +52,10 @@ get() ->
 get_xor_filter_devices() ->
     gen_server:call(?SERVER, get_xor_filter_devices).
 
+-spec get_devices() -> {ok, rocksdb:db_handle(), rocksdb:cf_handle()}.
+get_devices() ->
+    gen_server:call(?SERVER, get_devices).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
@@ -64,6 +69,9 @@ handle_call(get, _From, #state{db = DB, cfs = CFs} = State) ->
     {reply, {ok, DB, [DefaultCF, DevicesCF]}, State};
 handle_call(get_xor_filter_devices, _From, #state{db = DB, cfs = CFs} = State) ->
     CF = maps:get(xor_filter_devices, CFs),
+    {reply, {ok, DB, CF}, State};
+handle_call(get_devices, _From, #state{db = DB, cfs = CFs} = State) ->
+    CF = maps:get(devices, CFs),
     {reply, {ok, DB, CF}, State};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -75,7 +75,7 @@ mac_commands_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -160,7 +160,7 @@ dupes_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -495,7 +495,7 @@ dupes2_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -740,7 +740,7 @@ join_test(Config) ->
     ),
     ?assertEqual(CFList, <<>>),
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -948,7 +948,7 @@ adr_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_channel_aws_SUITE.erl
+++ b/test/router_channel_aws_SUITE.erl
@@ -116,7 +116,7 @@ aws_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -67,7 +67,7 @@ console_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -163,7 +163,7 @@ inactive_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_channel_http_SUITE.erl
+++ b/test/router_channel_http_SUITE.erl
@@ -72,7 +72,7 @@ http_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -407,7 +407,7 @@ http_update_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -90,7 +90,7 @@ mqtt_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -457,7 +457,7 @@ mqtt_update_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -64,7 +64,7 @@ no_channel_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_console_api_SUITE.erl
+++ b/test/router_console_api_SUITE.erl
@@ -78,7 +78,7 @@ consume_queue_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -238,7 +238,7 @@ fetch_queue_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, _Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_console_dc_tracker_SUITE.erl
+++ b/test/router_console_dc_tracker_SUITE.erl
@@ -60,7 +60,7 @@ dc_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -59,7 +59,7 @@ data_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -66,7 +66,7 @@ decode_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -141,7 +141,7 @@ template_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -176,7 +176,7 @@ timeout_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -264,7 +264,7 @@ too_many_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -360,7 +360,7 @@ late_packet_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -148,7 +148,7 @@ route_packet(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
     DevAddr = router_device:devaddr(Device0),

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -72,7 +72,7 @@ packet_hash_cache_test(Config) ->
     %% -------------------------------------------------------------------
     %% Device
     #{} = test_utils:join_device(Config),
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -265,7 +265,7 @@ multi_buy_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -348,7 +348,7 @@ bad_fcnt_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -78,7 +78,7 @@ device_worker_late_packet_double_charge_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerId = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device} = router_device:get_by_id(DB, CF, WorkerId),
 
@@ -339,7 +339,7 @@ device_update_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     DeviceID = ?CONSOLE_DEVICE_ID,
     ?assertMatch({ok, _}, router_device:get_by_id(DB, CF, DeviceID)),
 

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -90,7 +90,7 @@ console_tool_downlink_order_test(Config) ->
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
@@ -204,7 +204,7 @@ test_downlink_message_for_channel(Config, DownlinkPayload, DownlinkMessage, Expe
     test_utils:wait_state_channel_message(1250),
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -214,7 +214,7 @@ lw_join_test(Config) ->
     end,
 
     %% Check that device is in cache now
-    {ok, DB, [_, CF]} = router_db:get(),
+    {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 


### PR DESCRIPTION
If a device becomes unlinked from from an org somehow and router does
not catch that, it will continue to pull it from the database when
offers come in with the matching EUI or devaddr. Nothing can really get
rid of the device now because the supervisor didn't _actually_ start
anything, so there's nothing to kill, and we don't have any db sweeps to
clean out old devices.