### PR TITLE
Retry to get channels if it fails

### DIFF
--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -225,12 +225,12 @@ org_manual_update_router_dc(OrgID, Balance) ->
     end.
 
 -spec get_channels(Device :: router_device:device(), DeviceWorkerPid :: pid()) ->
-    [router_channel:channel()].
+    {ok, [router_channel:channel()]} | {error, any()}.
 get_channels(Device, DeviceWorkerPid) ->
     {Endpoint, Token} = token_lookup(),
     case get_device_(Endpoint, Token, Device) of
-        {error, _Reason} ->
-            [];
+        {error, _Reason} = Error ->
+            Error;
         {ok, JSON} ->
             Channels0 = kvc:path([<<"channels">>], JSON),
             Channels1 = lists:filtermap(
@@ -239,7 +239,7 @@ get_channels(Device, DeviceWorkerPid) ->
                 end,
                 Channels0
             ),
-            Channels1
+            {ok, Channels1}
     end.
 
 -spec event(Device :: router_device:device(), Map :: map()) -> ok.

--- a/src/device/router_device_channels_worker.erl
+++ b/src/device/router_device_channels_worker.erl
@@ -41,6 +41,7 @@
 ]).
 
 -define(SERVER, ?MODULE).
+-define(REFRESH_CHANNELS, refresh_channels).
 -define(BACKOFF_MIN, timer:seconds(15)).
 -define(BACKOFF_MAX, timer:minutes(5)).
 -define(BACKOFF_INIT,
@@ -170,7 +171,7 @@ new_data_cache(PubKeyBin, UUID, Packet, Frame, Region, Time, HoldTime) ->
 
 -spec refresh_channels(Pid :: pid()) -> ok.
 refresh_channels(Pid) ->
-    Pid ! refresh_channels,
+    Pid ! ?REFRESH_CHANNELS,
     ok.
 
 %% ------------------------------------------------------------------
@@ -342,40 +343,46 @@ handle_cast(_Msg, State) ->
 %% Channel Handling
 %% ------------------------------------------------------------------
 handle_info(
-    refresh_channels,
+    ?REFRESH_CHANNELS,
     #state{event_mgr = EventMgrRef, device = Device, channels = Channels0} = State
 ) ->
-    APIChannels = lists:foldl(
-        fun(Channel, Acc) ->
-            ID = router_channel:unique_id(Channel),
-            maps:put(ID, Channel, Acc)
-        end,
-        #{},
-        router_console_api:get_channels(Device, self())
-    ),
-    Channels1 =
-        case maps:size(APIChannels) == 0 of
-            true ->
-                %% API returned no channels removing all of them and adding the "no channel"
-                lists:foreach(
-                    fun
-                        ({router_no_channel, <<"no_channel">>}) -> ok;
-                        (Handler) -> gen_event:delete_handler(EventMgrRef, Handler, [])
-                    end,
-                    gen_event:which_handlers(EventMgrRef)
-                ),
-                NoChannel = maybe_start_no_channel(Device, EventMgrRef),
-                #{router_channel:unique_id(NoChannel) => NoChannel};
-            false ->
-                %% Start channels asynchronously
-                lists:foreach(
-                    fun(Channel) -> self() ! {start_channel, Channel} end,
-                    maps:values(APIChannels)
-                ),
-                %% Removing old channels left in cache but not in API call
-                remove_old_channels(EventMgrRef, APIChannels, Channels0)
-        end,
-    {noreply, State#state{channels = Channels1}};
+    case router_console_api:get_channels(Device, self()) of
+        {error, _Reason} ->
+            _ = erlang:send_after(timer:seconds(1), self(), ?REFRESH_CHANNELS),
+            lager:warning("failed to get channels ~p, retrying in 1s", [_Reason]);
+        {ok, APIChannels0} ->
+            APIChannels1 = lists:foldl(
+                fun(Channel, Acc) ->
+                    ID = router_channel:unique_id(Channel),
+                    maps:put(ID, Channel, Acc)
+                end,
+                #{},
+                APIChannels0
+            ),
+            Channels1 =
+                case maps:size(APIChannels1) == 0 of
+                    true ->
+                        %% API returned no channels removing all of them and adding the "no channel"
+                        lists:foreach(
+                            fun
+                                ({router_no_channel, <<"no_channel">>}) -> ok;
+                                (Handler) -> gen_event:delete_handler(EventMgrRef, Handler, [])
+                            end,
+                            gen_event:which_handlers(EventMgrRef)
+                        ),
+                        NoChannel = maybe_start_no_channel(Device, EventMgrRef),
+                        #{router_channel:unique_id(NoChannel) => NoChannel};
+                    false ->
+                        %% Start channels asynchronously
+                        lists:foreach(
+                            fun(Channel) -> self() ! {start_channel, Channel} end,
+                            maps:values(APIChannels1)
+                        ),
+                        %% Removing old channels left in cache but not in API call
+                        remove_old_channels(EventMgrRef, APIChannels1, Channels0)
+                end,
+            {noreply, State#state{channels = Channels1}}
+    end;
 handle_info(
     {start_channel, Channel},
     #state{


### PR DESCRIPTION
Fix for issue #484

If the API is having issue we do not try refetch channels and just return an empty list. We now, will retry to get channels (integrations) if the first API call failed to ensure proper channel startup