### PR TITLE
Make sure we fail CI if #downlink{} or #channel{} are changed

### DIFF
--- a/src/channels/router_channel.erl
+++ b/src/channels/router_channel.erl
@@ -563,4 +563,33 @@ hash_test() ->
     Hash = crypto:hash(sha256, erlang:term_to_binary(Channel1)),
     ?assertEqual(Hash, hash(Channel0)).
 
+channel_record_update_test() ->
+    %% This test exists to make sure upgrades are considered if anything needs
+    %% to touch the #channel{} record definition.
+    ?assertMatch(
+        {
+            channel,
+            _Id,
+            _Handler,
+            _Name,
+            _Args,
+            _DeviceID,
+            _Controller,
+            _Decoder,
+            _PayloadTemplate,
+            _ChannelOptions
+        },
+        new(
+            <<"channel_id">>,
+            router_http_channel,
+            <<"channel_name">>,
+            [],
+            <<"device_id">>,
+            self(),
+            <<>>,
+            <<>>,
+            #{receive_joins => true}
+        )
+    ).
+
 -endif.

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -2165,3 +2165,21 @@ maybe_will_downlink(Device, #frame{mtype = MType, adrackreq = ADRAckReqBit}) ->
     ChannelCorrection = router_device:channel_correction(Device),
     ADR = ADRAllowed andalso ADRAckReqBit == 1,
     DeviceQueue =/= [] orelse ACK == 1 orelse ADR orelse ChannelCorrection == false.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+channel_record_update_test() ->
+    %% This test exists to make sure upgrades are considered if anything needs
+    %% to touch the #downlink{} record definition.
+    ?assertMatch(
+        {
+            downlink,
+            _Confirmed,
+            _Port,
+            _Payload,
+            _Channel
+        },
+        #downlink{}
+    ).
+-endif.


### PR DESCRIPTION
These tests will mostly protect from fields that are added to the record.
All fields exist in these records exist because we use them somewhere.
If a field name is changed the compiler will warn us.
If a field is removed, same complaint.