### PR TITLE
Graceful recovery of worker after javascript errors

### DIFF
--- a/config/test.config
+++ b/config/test.config
@@ -3,7 +3,7 @@
     {router, [
         {oui, 1},
         {metrics, [{reporters, []}]},
-        {max_v8_context, 1},
+        {max_v8_context, 10},
         {router_http_channel_url_check, false},
         {router_xor_filter_worker, false},
         {charge_when_no_offer, true}

--- a/src/decoders/router_decoder_custom_sup.erl
+++ b/src/decoders/router_decoder_custom_sup.erl
@@ -91,18 +91,9 @@ add(Decoder) ->
     add(ID, Function).
 
 -spec delete(binary()) -> ok.
--ifdef(TEST).
-delete(ID) ->
-    case ets:info(?ETS, size) of
-        undefined -> ok;
-        _ -> ets:delete(?ETS, ID)
-    end,
-    ok.
--else.
 delete(ID) ->
     true = ets:delete(?ETS, ID),
     ok.
--endif.
 
 -spec decode(
     Decoder :: router_decoder:decoder(),

--- a/src/decoders/router_decoder_custom_sup.erl
+++ b/src/decoders/router_decoder_custom_sup.erl
@@ -91,9 +91,18 @@ add(Decoder) ->
     add(ID, Function).
 
 -spec delete(binary()) -> ok.
+-ifdef(TEST).
+delete(ID) ->
+    case ets:info(?ETS, size) of
+        undefined -> ok;
+        _ -> ets:delete(?ETS, ID)
+    end,
+    ok.
+-else.
 delete(ID) ->
     true = ets:delete(?ETS, ID),
     ok.
+-endif.
 
 -spec decode(
     Decoder :: router_decoder:decoder(),
@@ -130,7 +139,7 @@ init([]) ->
 
 -spec add(DecoderID :: binary(), Function :: binary()) -> {ok, pid()} | {error, any()}.
 add(ID, Function) ->
-    case is_valid_decoder_function(Function) of
+    case contains_decoder_function(Function) of
         false ->
             {error, no_decoder_fun_found};
         true ->
@@ -152,7 +161,7 @@ add(ID, Function) ->
     {ok, pid()} | {error, any()}.
 start_worker(ID, Hash, Function) ->
     {ok, VM} = router_v8:get(),
-    Args = #{id => ID, vm => VM, function => Function},
+    Args = #{id => ID, vm => VM, function => Function, hash => Hash},
     case supervisor:start_child(?MODULE, [Args]) of
         {error, _Err} = Err ->
             Err;
@@ -220,8 +229,8 @@ get_oldest_decoder() ->
             end
     end.
 
--spec is_valid_decoder_function(binary()) -> boolean().
-is_valid_decoder_function(Function) ->
+-spec contains_decoder_function(binary()) -> boolean().
+contains_decoder_function(Function) ->
     case re:run(Function, ?DECODER_FUNCTION_REGEX) of
         nomatch ->
             false;
@@ -277,59 +286,59 @@ get_oldest_decoder_test() ->
     ?assertEqual(CustomDecoder0, get_oldest_decoder()),
     true = ets:delete(?ETS).
 
-is_valid_decoder_function_test_() ->
+contains_decoder_function_test_() ->
     [
         %%% VALID FUNCTIONS
         %% normal, original style
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder(bytes, port) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder(bytes, port) {}">>)),
         %% normal, with arg for #439
         ?_assertMatch(
             true,
-            is_valid_decoder_function(<<"function Decoder(bytes, port, uplink_details) {}">>)
+            contains_decoder_function(<<"function Decoder(bytes, port, uplink_details) {}">>)
         ),
         %% single spaces
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (bytes, port) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (bytes, port) {}">>)),
         %% multiple spaces right side
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder    (bytes, port) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder    (bytes, port) {}">>)),
         %% tabs
-        ?_assertMatch(true, is_valid_decoder_function(<<"function\tDecoder\t(bytes, port) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function\tDecoder\t(bytes, port) {}">>)),
         %% newlines
-        ?_assertMatch(true, is_valid_decoder_function(<<"function\nDecoder\n(bytes, port) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function\nDecoder\n(bytes, port) {}">>)),
         %% multiple spaces both sides
         ?_assertMatch(
             true,
-            is_valid_decoder_function(<<"function    Decoder    (bytes, port) {}">>)
+            contains_decoder_function(<<"function    Decoder    (bytes, port) {}">>)
         ),
         %% different argument names
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (one, two) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (one, two) {}">>)),
         %% single letter arguments
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (a,b) {}">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (a,b) {}">>)),
         %% Leading parenthesis allergic whitespace
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (  a, b)">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (  a, b)">>)),
         %% Closing parenthesis allergic  whitespace
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (a, b  )">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (a, b  )">>)),
         %% Paren alergic whitespace
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (  a, b    )">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (  a, b    )">>)),
         %% Parent allergic whitesapce with optional 3rd arg
-        ?_assertMatch(true, is_valid_decoder_function(<<"function Decoder (  a,  b,  c  )">>)),
+        ?_assertMatch(true, contains_decoder_function(<<"function Decoder (  a,  b,  c  )">>)),
 
         %%% INVALID FUNCTIONS
         %% lowercase function name
-        ?_assertMatch(false, is_valid_decoder_function(<<"function decoder (bytes, port) {}">>)),
+        ?_assertMatch(false, contains_decoder_function(<<"function decoder (bytes, port) {}">>)),
         %% single argument
-        ?_assertMatch(false, is_valid_decoder_function(<<"function Decoder (bytes) {}">>)),
+        ?_assertMatch(false, contains_decoder_function(<<"function Decoder (bytes) {}">>)),
         %% no arguments
-        ?_assertMatch(false, is_valid_decoder_function(<<"function Decoder () {}">>)),
+        ?_assertMatch(false, contains_decoder_function(<<"function Decoder () {}">>)),
         %% mispelled function name
-        ?_assertMatch(false, is_valid_decoder_function(<<"function Decodre (bytes, port) {}">>)),
+        ?_assertMatch(false, contains_decoder_function(<<"function Decodre (bytes, port) {}">>)),
         %% missing space after function
-        ?_assertMatch(false, is_valid_decoder_function(<<"functionDecoder (bytes, port) {}">>)),
+        ?_assertMatch(false, contains_decoder_function(<<"functionDecoder (bytes, port) {}">>)),
         %% trailing command within arg list
-        ?_assertMatch(false, is_valid_decoder_function(<<"function Decoder(bytes, port,) {}">>)),
+        ?_assertMatch(false, contains_decoder_function(<<"function Decoder(bytes, port,) {}">>)),
         %% illegal space within variadic arg syntax
         ?_assertMatch(
             false,
-            is_valid_decoder_function(<<"function Decoder(bytes, port, ... rest) {}">>)
+            contains_decoder_function(<<"function Decoder(bytes, port, ... rest) {}">>)
         )
     ].
 

--- a/src/decoders/router_decoder_custom_worker.erl
+++ b/src/decoders/router_decoder_custom_worker.erl
@@ -105,7 +105,7 @@ init(Args) ->
             {js_error, Error} ->
                 %% When eval fails, avoid calls to that JavaScript function
                 %% but need this worker (erlang process) to accommodate that
-                ShortSHA = binary:part(maps:get(hash, Args), 0, 7),
+                ShortSHA = binary:part(maps:get(hash, Args, <<"unknown">>), 0, 7),
                 lager:error(
                     "V8 javascript eval failed decoder_id=~p hash=~p error=~p",
                     [ID, ShortSHA, Error]

--- a/src/decoders/router_decoder_custom_worker.erl
+++ b/src/decoders/router_decoder_custom_worker.erl
@@ -218,7 +218,8 @@ terminate(_Reason, #state{id = ID, vm = VM, context = Context} = _State) ->
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
 
--spec init_context(VMPid :: pid(), Function :: binary()) -> {ok, context()} | {error, any()} | {context_error, any()} | {js_error, any()}.
+-spec init_context(VMPid :: pid(), Function :: binary()) ->
+    {ok, context()} | {error, any()} | {context_error, any()} | {js_error, any()}.
 init_context(VM, Function) ->
     case erlang_v8:create_context(VM) of
         {error, Error0} = Error0 ->

--- a/src/decoders/router_decoder_custom_worker.erl
+++ b/src/decoders/router_decoder_custom_worker.erl
@@ -212,6 +212,13 @@ decode(
         {error, invalid_context} ->
             {ok, Context1} = init_context(VM, Function),
             decode(Payload, Port, UplinkDetails, State#state{context = Context1}, Retry - 1);
+        {error, Err} when is_binary(Err) ->
+            ShortReason =
+                case binary:match(Err, <<"\n">>) of
+                    {End, _} -> binary:part(Err, 0, End);
+                    nomatch -> Err
+                end,
+            {{js_error, ShortReason}, State#state{function = <<>>}};
         {error, Err} ->
             %% TODO this eliminates any tolerance for intermittent
             %% errors such as an occasional payload crashing their

--- a/src/decoders/router_decoder_custom_worker.erl
+++ b/src/decoders/router_decoder_custom_worker.erl
@@ -47,7 +47,7 @@
 
 -record(state, {
     id :: binary(),
-    vm :: pid(),
+    vm :: pid() | undefined,
     context :: context() | undefined,
     function :: binary(),
     timer :: reference(),
@@ -218,7 +218,7 @@ terminate(_Reason, #state{id = ID, vm = VM, context = Context} = _State) ->
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
 
--spec init_context(VMPid :: pid(), Function :: binary()) -> {ok, context()} | {error, any()}.
+-spec init_context(VMPid :: pid(), Function :: binary()) -> {ok, context()} | {error, any()} | {context_error, any()} | {js_error, any()}.
 init_context(VM, Function) ->
     case erlang_v8:create_context(VM) of
         {error, Error0} = Error0 ->
@@ -279,7 +279,7 @@ decode(
         )
     of
         {error, invalid_context} ->
-            Context1 = init_context(VM, Function),
+            {ok, Context1} = init_context(VM, Function),
             %% TODO: use Ferd's `backoff' library.
             %% See stateful use: ../device/router_device_channels_worker.erl
             decode(Payload, Port, UplinkDetails, State#state{context = Context1}, Retry - 1);

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -259,6 +259,9 @@ timeout_test(Config) ->
     ok.
 
 too_many_test(Config) ->
+    MaxV8Context = application:get_env(router, max_v8_context, 10),
+    ok = application:set_env(router, max_v8_context, 1),
+
     %% Set console to decoder channel mode
     Tab = proplists:get_value(ets, Config),
     ets:insert(Tab, {channel_type, decoder}),
@@ -346,6 +349,8 @@ too_many_test(Config) ->
     }),
     ok = router_decoder:add(NewDecoder),
 
+    %% This assumes max_v8_context = 1 within ../config/test.config or equivalent,
+    %% so see application:set_env() above and original value restored below.
     ?assertNot(erlang:is_process_alive(DecoderPid)),
 
     NewDecoderID = router_decoder:id(NewDecoder),
@@ -354,7 +359,8 @@ too_many_test(Config) ->
     ?assertEqual({ok, undefined}, router_decoder:decode(DecoderID, <<>>, 1, #{})),
     ?assertEqual({ok, <<"ok">>}, router_decoder:decode(NewDecoderID, <<>>, 1, #{})),
     ?assertEqual(1, ets:info(router_decoder_custom_sup_ets, size)),
-    ok.
+
+    ok = application:set_env(router, max_v8_context, MaxV8Context).
 
 %% ------------------------------------------------------------------
 %% Helper functions

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -10,8 +10,7 @@
     decode_test/1,
     template_test/1,
     timeout_test/1,
-    too_many_test/1,
-    v8_recovery_test/1
+    too_many_test/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -38,8 +37,7 @@ all() ->
         decode_test,
         template_test,
         timeout_test,
-        too_many_test,
-        v8_recovery_test
+        too_many_test
     ].
 
 %%--------------------------------------------------------------------
@@ -353,34 +351,6 @@ too_many_test(Config) ->
     ?assertEqual({ok, undefined}, router_decoder:decode(DecoderID, <<>>, 1, #{})),
     ?assertEqual({ok, <<"ok">>}, router_decoder:decode(NewDecoderID, <<>>, 1, #{})),
     ?assertEqual(1, ets:info(router_decoder_custom_sup_ets, size)),
-    ok.
-
-v8_recovery_test(Config) ->
-    %% Set console to decoder channel mode
-    Tab = proplists:get_value(ets, Config),
-    ets:insert(Tab, {channel_type, decoder}),
-
-    test_utils:join_device(Config),
-
-    %% Waiting for reply from router to hotspot
-    test_utils:wait_state_channel_message(1250),
-
-    ValidDecoder = <<"function Decoder(a,b,c) { return 42; }">>,
-    Result = 42,
-    BogusDecoder = <<"function Decoder(a,b,c) { crash @ here! }">>,
-    Port = 6,
-    Payload = erlang:binary_to_list(base64:decode(<<"H4Av/xACRU4=">>)),
-    UplinkDetails = #{},
-
-    %% One context sends a valid function definiton and another sends
-    %% bogus javascript, causing the V8 VM to be restarted.  The first
-    %% context should then recover.
-    {ok, Pid} = router_decoder_custom_sup:add(ValidDecoder),
-    {ok, Result} = router_decoder_custom_worker:decode(Pid, Payload, Port, UplinkDetails),
-    {eval_error, _} = router_decoder_custom_sup:add(BogusDecoder),
-    {ok, Result} = router_decoder_custom_worker:decode(Pid, Payload, Port, UplinkDetails),
-
-    %% FIXME: how can we force bad context?
     ok.
 
 %% ------------------------------------------------------------------

--- a/test/router_decoder_custom_sup_SUITE.erl
+++ b/test/router_decoder_custom_sup_SUITE.erl
@@ -1,0 +1,110 @@
+-module(router_decoder_custom_sup_SUITE).
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    v8_recovery_test/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [
+        v8_recovery_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    test_utils:init_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(TestCase, Config) ->
+    test_utils:end_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+v8_recovery_test(Config) ->
+    %% Set console to decoder channel mode
+    Tab = proplists:get_value(ets, Config),
+    ets:insert(Tab, {channel_type, decoder}),
+
+    test_utils:join_device(Config),
+
+    %% Waiting for reply from router to hotspot
+    test_utils:wait_state_channel_message(1250),
+
+    ValidFunction = <<"function Decoder(a,b,c) { return 42; }">>,
+    ValidDecoder = router_decoder:new(
+          <<"valid">>,
+          custom,
+          #{function => ValidFunction}
+    ),
+    Result = 42,
+    BogusFunction = <<"function Decoder(a,b,c) { crash @ here! }">>,
+    BogusDecoder = router_decoder:new(
+          <<"bogus">>,
+          custom,
+          #{function => BogusFunction}
+    ),
+    Payload = erlang:binary_to_list(base64:decode(<<"H4Av/xACRU4=">>)),
+    Port = 6,
+    Uplink = #{},
+
+    %% One context sends a valid function definiton and another sends
+    %% bogus javascript, causing the V8 VM to be restarted.  The first
+    %% context should then recover.
+    {ok, Pid1} = router_decoder_custom_sup:add(ValidDecoder),
+    ?assertMatch({ok, Result},
+                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
+    ?assertMatch({ok, Result},
+                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
+    ?assertMatch({ok, Result},
+                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
+    ?assert(erlang:is_process_alive(Pid1)),
+
+    %% Even though JS was bad, we still get a Pid for less BEAM runtime overhead overall
+    {ok, Pid2} = router_decoder_custom_sup:add(BogusDecoder),
+    ?assertNotMatch(Pid1, Pid2),
+    %% FIXME: starting 2nd proc kills 1st, but why?
+    %% something is calling router_decoder_custom_worker:terminate(), but what?
+    ?assert(erlang:is_process_alive(Pid1)),
+    ?assertMatch({error, ignoring_invalid_javascript},
+                 router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
+    ?assert(erlang:is_process_alive(Pid1)),
+    ?assertMatch({error, ignoring_invalid_javascript},
+                 router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
+    ?assert(erlang:is_process_alive(Pid1)),
+    ?assertMatch({error, ignoring_invalid_javascript},
+                 router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
+    ?assert(erlang:is_process_alive(Pid1)),
+    ?assert(erlang:is_process_alive(Pid2)),
+
+    %% FIXME: crashing due to noproc error from gen_server:
+    ?assert(erlang:is_process_alive(Pid1)),
+    ?assertMatch({ok, Result},
+                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
+
+    %% FIXME: how can we force bad context?
+
+    ok.

--- a/test/router_decoder_custom_sup_SUITE.erl
+++ b/test/router_decoder_custom_sup_SUITE.erl
@@ -56,16 +56,16 @@ v8_recovery_test(Config) ->
 
     ValidFunction = <<"function Decoder(a,b,c) { return 42; }">>,
     ValidDecoder = router_decoder:new(
-          <<"valid">>,
-          custom,
-          #{function => ValidFunction}
+        <<"valid">>,
+        custom,
+        #{function => ValidFunction}
     ),
     Result = 42,
     BogusFunction = <<"function Decoder(a,b,c) { crash @ here! }">>,
     BogusDecoder = router_decoder:new(
-          <<"bogus">>,
-          custom,
-          #{function => BogusFunction}
+        <<"bogus">>,
+        custom,
+        #{function => BogusFunction}
     ),
     Payload = erlang:binary_to_list(base64:decode(<<"H4Av/xACRU4=">>)),
     Port = 6,
@@ -75,27 +75,41 @@ v8_recovery_test(Config) ->
     %% bogus javascript, causing the V8 VM to be restarted.  The first
     %% context should then recover.
     {ok, Pid1} = router_decoder_custom_sup:add(ValidDecoder),
-    ?assertMatch({ok, Result},
-                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
-    ?assertMatch({ok, Result},
-                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
-    ?assertMatch({ok, Result},
-                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
+    ?assertMatch(
+        {ok, Result},
+        router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)
+    ),
+    ?assertMatch(
+        {ok, Result},
+        router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)
+    ),
+    ?assertMatch(
+        {ok, Result},
+        router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)
+    ),
     ?assert(erlang:is_process_alive(Pid1)),
 
     %% Even though JS was bad, we still get a Pid for less BEAM runtime overhead overall
     {ok, Pid2} = router_decoder_custom_sup:add(BogusDecoder),
     ?assertNotMatch(Pid1, Pid2),
-    ?assertMatch({error, ignoring_invalid_javascript},
-                 router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
-    ?assertMatch({error, ignoring_invalid_javascript},
-                 router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
-    ?assertMatch({error, ignoring_invalid_javascript},
-                 router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)
+    ),
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)
+    ),
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)
+    ),
 
     ?assert(erlang:is_process_alive(Pid1)),
-    ?assertMatch({ok, Result},
-                 router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),
+    ?assertMatch(
+        {ok, Result},
+        router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)
+    ),
 
     %% FIXME: how can we force bad context?
 

--- a/test/router_decoder_custom_sup_SUITE.erl
+++ b/test/router_decoder_custom_sup_SUITE.erl
@@ -110,7 +110,4 @@ v8_recovery_test(Config) ->
         {ok, Result},
         router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)
     ),
-
-    %% FIXME: how can we force bad context?
-
     ok.

--- a/test/router_decoder_custom_sup_SUITE.erl
+++ b/test/router_decoder_custom_sup_SUITE.erl
@@ -86,21 +86,13 @@ v8_recovery_test(Config) ->
     %% Even though JS was bad, we still get a Pid for less BEAM runtime overhead overall
     {ok, Pid2} = router_decoder_custom_sup:add(BogusDecoder),
     ?assertNotMatch(Pid1, Pid2),
-    %% FIXME: starting 2nd proc kills 1st, but why?
-    %% something is calling router_decoder_custom_worker:terminate(), but what?
-    ?assert(erlang:is_process_alive(Pid1)),
     ?assertMatch({error, ignoring_invalid_javascript},
                  router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
-    ?assert(erlang:is_process_alive(Pid1)),
     ?assertMatch({error, ignoring_invalid_javascript},
                  router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
-    ?assert(erlang:is_process_alive(Pid1)),
     ?assertMatch({error, ignoring_invalid_javascript},
                  router_decoder_custom_worker:decode(Pid2, Payload, Port, Uplink)),
-    ?assert(erlang:is_process_alive(Pid1)),
-    ?assert(erlang:is_process_alive(Pid2)),
 
-    %% FIXME: crashing due to noproc error from gen_server:
     ?assert(erlang:is_process_alive(Pid1)),
     ?assertMatch({ok, Result},
                  router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)),

--- a/test/router_decoder_custom_worker_SUITE.erl
+++ b/test/router_decoder_custom_worker_SUITE.erl
@@ -58,10 +58,13 @@ avoid_call_to_bad_js_test(_Config) ->
     Port = 6,
     Uplink = #{},
     %% First time through decode() visits init_context()
-    ?assertMatch(
-        {js_error, <<"ReferenceError:", _/binary>>},
-        router_decoder_custom_worker:decode(Pid, Payload, Port, Uplink)
-    ),
+    Decoded = router_decoder_custom_worker:decode(Pid, Payload, Port, Uplink),
+    ?assertMatch({js_error, <<"ReferenceError:", _/binary>>}, Decoded),
+
+    %% While were here, confirm abbreviated message (which gets used in log entry)
+    {js_error, <<"ReferenceError:", OmitFullStackTrace/binary>>} = Decoded,
+    ?assertMatch(nomatch, binary:match(OmitFullStackTrace, <<"\n">>)),
+
     %% Subsequent trips through decode/4 should avoid calling V8
     ?assertMatch(
         {error, ignoring_invalid_javascript},

--- a/test/router_decoder_custom_worker_SUITE.erl
+++ b/test/router_decoder_custom_worker_SUITE.erl
@@ -1,0 +1,101 @@
+-module(router_decoder_custom_worker_SUITE).
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    avoid_call_to_bad_js_test/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [avoid_call_to_bad_js_test].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+avoid_call_to_bad_js_test(_Config) ->
+    InvalidDecoder = <<"function Decoder(a,b,c) { crash + burn; }">>,
+    {ok, VM} = router_v8:start_link(#{}),
+    V8VM =
+        case erlang_v8:start_vm() of
+            {ok, V8Pid} -> V8Pid;
+            {error, {already_started, V8Pid}} -> V8Pid
+        end,
+    Args = #{
+        id => <<"decoder_id">>,
+        hash => <<"cafef00d">>,
+        function => InvalidDecoder,
+        vm => V8VM
+    },
+    {ok, Pid} = router_decoder_custom_worker:start_link(Args),
+
+    Payload = <<"doesn't matter for this test case">>,
+    Port = 6,
+    Uplink = #{},
+    %% First time through decode() visits init_context()
+    ?assertMatch(
+        {js_error, <<"ReferenceError:", _/binary>>},
+        router_decoder_custom_worker:decode(Pid, Payload, Port, Uplink)
+    ),
+    %% Subsequent trips through decode/4 should avoid calling V8
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid, Payload, Port, Uplink)
+    ),
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid, Payload, Port, Uplink)
+    ),
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid, Payload, Port, Uplink)
+    ),
+
+    MalformedJS1 = <<"funct Decoder(a,b,c) { return 42; }">>,
+    Args1 = #{
+        id => <<"decoder_id1">>,
+        hash => <<"badca112">>,
+        function => MalformedJS1,
+        vm => V8VM
+    },
+    %% Worker gets created regardless of an error, because it will be
+    %% less overhead overall (compared to rejecting and having next
+    %% packet start fresh).
+    {ok, Pid1} = router_decoder_custom_worker:start_link(Args1),
+    %% Now, first call to decode gets ignored
+    ?assertMatch(
+        {error, ignoring_invalid_javascript},
+        router_decoder_custom_worker:decode(Pid1, Payload, Port, Uplink)
+    ),
+
+    %% Cleanup:
+    %% skipping: gen_server:stop(Pid),
+    %% skipping: gen_server:stop(Pid1),
+    gen_server:stop(VM),
+    gen_server:stop(V8VM),
+    ok.

--- a/test/router_v8_SUITE.erl
+++ b/test/router_v8_SUITE.erl
@@ -1,0 +1,100 @@
+-module(router_v8_SUITE).
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    invalid_context_test/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [invalid_context_test].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    test_utils:init_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(TestCase, Config) ->
+    test_utils:end_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+invalid_context_test(_Config) ->
+    GoodFunction =
+        <<"function Decoder(bytes, port) {\n"
+            "  var payload = {\"Testing\": \"42\"};\n"
+            "  return payload;\n"
+            "}">>,
+    BadFunction = <<"function Decoder() { returrrrrrrn 0; }">>,
+
+    VMPid =
+        case router_v8:start_link(#{}) of
+            {ok, Pid} -> Pid;
+            {error, {already_started, Pid}} -> Pid
+        end,
+    {ok, VM} = router_v8:get(),
+    {ok, Context1} = erlang_v8:create_context(VM),
+    {ok, Context2} = erlang_v8:create_context(VM),
+    ?assertNotMatch(Context1, Context2),
+
+    Payload = erlang:binary_to_list(base64:decode(<<"H4Av/xACRU4=">>)),
+    Port = 6,
+    Result = #{<<"Testing">> => <<"42">>},
+
+    %% Eval good function and ensure function works more than once
+    ?assertMatch({ok, undefined}, erlang_v8:eval(VM, Context1, GoodFunction)),
+    ?assertMatch({ok, Result}, erlang_v8:call(VM, Context1, <<"Decoder">>, [Payload, Port])),
+    ?assertMatch({ok, Result}, erlang_v8:call(VM, Context1, <<"Decoder">>, [Payload, Port])),
+
+    %% Call undefined function
+    ?assertMatch(
+        {error, <<"ReferenceError: Decoder is not defined", _/binary>>},
+        erlang_v8:call(VM, Context2, <<"Decoder">>, [Payload, Port])
+    ),
+
+    %% First Context still works
+    ?assertMatch({ok, Result}, erlang_v8:call(VM, Context1, <<"Decoder">>, [Payload, Port])),
+
+    %% Eval bad function
+    ?assertMatch({error, crashed}, erlang_v8:eval(VM, Context2, BadFunction)),
+
+    %% Upon an error (other than invalid_source_size), v8 Port gets
+    %% killed and restarted
+    ?assertMatch(true, erlang:is_process_alive(VMPid)),
+
+    %% Unintuitively, we get invalid context when attempting to reuse first Context:
+    ?assertMatch(
+        {error, invalid_context},
+        erlang_v8:call(VM, Context1, <<"Decoder">>, [Payload, Port])
+    ),
+    %% But that's because set of Context needs to be repopulated within V8's VM:
+    erlang_v8:restart_vm(VM),
+
+    %% First Context no longer works-- not ideal behavior but what we
+    %% have at hand.  Ideally, return value would still match `Result'.
+    ?assertMatch(
+        {error, invalid_context},
+        erlang_v8:call(VM, Context1, <<"Decoder">>, [Payload, Port])
+    ),
+
+    gen_server:stop(VMPid),
+    ok.


### PR DESCRIPTION
When a custom decoder function (written in JavaScript) fails, this PR has router track that it failed and avoids further calls to V8 VM for it.

An Erlang process still gets created, because overall, that leads to less computation at runtime when subsequent frames arrive to be passed through that custom decoder.

(There may be room for improvement.  It may be possible to terminate the Erlang process and test earlier in the work-flow when subsequent frames arrive yet before attempting to message the process.)

This partially addresses the reason why issue  #486 was created.

This fixes issue #495 for multiple causes that lead to why `no_context` was being returned within `decoded` object for custom decoders.