### PR TITLE
add read/write concurrency to routing ets

### DIFF
--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -109,10 +109,17 @@
 
 -spec init() -> ok.
 init() ->
-    ets:new(?ETS, [public, named_table, set]),
-    ets:new(?MB_ETS, [public, named_table, set]),
-    ets:new(?BF_ETS, [public, named_table, set]),
-    ets:new(?REPLAY_ETS, [public, named_table, set]),
+    Options = [
+        public,
+        named_table,
+        set,
+        {write_concurrency, true},
+        {read_concurrency, true}
+    ],
+    ets:new(?ETS, Options),
+    ets:new(?MB_ETS, Options),
+    ets:new(?BF_ETS, Options),
+    ets:new(?REPLAY_ETS, Options),
     {ok, BloomJoinRef} = bloom:new_forgetful(
         ?BF_BITMAP_SIZE,
         ?BF_UNIQ_CLIENTS_MAX,


### PR DESCRIPTION
State Channels were recently made parallel.
I think this would help in cases of unlimited buy. 
Need some more heads to think through what would happen on limited buy, and 1 buy.

Questions:
Is there a chance we can accidentally buy too many packets?