### PR TITLE
Add EU868 payload size map

### DIFF
--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -43,6 +43,7 @@
 -define(CN470_MAX_DOWNLINK_SIZE, 242).
 -define(AS923_MAX_DOWNLINK_SIZE, 250).
 -define(AU915_MAX_DOWNLINK_SIZE, 250).
+-define(EU868_MAX_DOWNLINK_SIZE, 222).
 
 -define(AS923_PAYLOAD_SIZE_MAP, #{
     0 => 59,
@@ -98,6 +99,18 @@
     13 => 250
     %% 14 => undefined,
     %% 15 => undefined,
+}).
+
+-define(EU868_PAYLOAD_SIZE_MAP, #{
+    0 => 51,
+    1 => 51,
+    2 => 51,
+    3 => 115,
+    4 => 222,
+    5 => 222,
+    6 => 222,
+    7 => 222,
+    %% 8..15 => undefined,
 }).
 
 %% ------------------------------------------------------------------
@@ -213,6 +226,7 @@ max_payload_size(Region, DR) ->
         'AS923' -> maps:get(DR, ?AS923_PAYLOAD_SIZE_MAP, ?AS923_MAX_DOWNLINK_SIZE);
         'CN470' -> maps:get(DR, ?CN470_PAYLOAD_SIZE_MAP, ?CN470_MAX_DOWNLINK_SIZE);
         'AU915' -> maps:get(DR, ?AU915_PAYLOAD_SIZE_MAP, ?AU915_MAX_DOWNLINK_SIZE);
+	'EU868' -> maps:get(DR, ?EU868_PAYLOAD_SIZE_MAP, ?EU868_MAX_DOWNLINK_SIZE);
         _ -> maps:get(DR, ?US915_PAYLOAD_SIZE_MAP, ?US915_MAX_DOWNLINK_SIZE)
     end.
 

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -109,8 +109,8 @@
     4 => 222,
     5 => 222,
     6 => 222,
-    7 => 222,
-    %% 8..15 => undefined,
+    7 => 222
+    %% 8..15 => undefined
 }).
 
 %% ------------------------------------------------------------------
@@ -226,7 +226,7 @@ max_payload_size(Region, DR) ->
         'AS923' -> maps:get(DR, ?AS923_PAYLOAD_SIZE_MAP, ?AS923_MAX_DOWNLINK_SIZE);
         'CN470' -> maps:get(DR, ?CN470_PAYLOAD_SIZE_MAP, ?CN470_MAX_DOWNLINK_SIZE);
         'AU915' -> maps:get(DR, ?AU915_PAYLOAD_SIZE_MAP, ?AU915_MAX_DOWNLINK_SIZE);
-	'EU868' -> maps:get(DR, ?EU868_PAYLOAD_SIZE_MAP, ?EU868_MAX_DOWNLINK_SIZE);
+        'EU868' -> maps:get(DR, ?EU868_PAYLOAD_SIZE_MAP, ?EU868_MAX_DOWNLINK_SIZE);
         _ -> maps:get(DR, ?US915_PAYLOAD_SIZE_MAP, ?US915_MAX_DOWNLINK_SIZE)
     end.
 


### PR DESCRIPTION
It looks like the US table is used for EU868 as well. 
Reading
https://lora-developers.semtech.com/documentation/tech-papers-and-guides/the-book/packet-size-considerations
this should be different for EU868.