### PR TITLE
Increase RX1_DELAY and RX2_DELAY by 1s for internet latency tolerance

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1877,7 +1877,9 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
             false ->
                 FOpts1
         end,
-    {ChannelsCorrected orelse ChannelCorrection, FOpts2}.
+    Rx2Delay = lorawan_mac_region:rx2_window(),
+    FOpts3 = [{rx_timing_setup_req, Rx2Delay} | FOpts2],
+    {ChannelsCorrected orelse ChannelCorrection, FOpts3}.
 
 %% TODO: with ADR implemented, this function, or at least its name,
 %%       doesn't make much sense anymore; it may return true for any

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -1067,6 +1067,10 @@ us915_link_adr_req_timing_test(Config) ->
                         <<"channel_mask">> => fun erlang:is_integer/1,
                         <<"channel_mask_control">> => fun erlang:is_integer/1,
                         <<"number_of_transmissions">> => fun erlang:is_integer/1
+                    },
+                    #{
+                        <<"command">> => <<"rx_timing_setup_req">>,
+                        <<"delay">> => fun erlang:is_integer/1
                     }
                 ]
             }
@@ -1452,6 +1456,10 @@ adr_downlink_timing_test(Config) ->
                         <<"data_rate">> => 3,
                         <<"number_of_transmissions">> => 0,
                         <<"tx_power">> => 7
+                    },
+                    #{
+                        <<"command">> => <<"rx_timing_setup_req">>,
+                        <<"delay">> => fun erlang:is_integer/1
                     }
                 ]
             }

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -286,6 +286,10 @@ device_worker_late_packet_double_charge_test(Config) ->
                     <<"data_rate">> => 2,
                     <<"number_of_transmissions">> => 0,
                     <<"tx_power">> => 0
+                },
+                #{
+                    <<"command">> => <<"rx_timing_setup_req">>,
+                    <<"delay">> => fun erlang:is_integer/1
                 }
             ]
         }


### PR DESCRIPTION
**DO NOT MERGE -- this should have been created as a DRAFT PR and is incomplete / not yet correct.**

This should resolve issue #531 since internet latency seems to be a contributing factor there.

This increases the defaults for all regions because router lacks any configuration item specifying the region within which it's deployed.

This PR does NOT make this value configurable yet, as that feature hasn't been merged for Console.

Added comments within the source code to assist when needing to correlate the LoRaWAN spec with the code and vice versa.