### PR TITLE
Remove a channels backoff when it's deleted

### DIFF
--- a/src/device/router_device_channels_worker.erl
+++ b/src/device/router_device_channels_worker.erl
@@ -60,13 +60,16 @@
     replay :: boolean()
 }).
 
+-type channel_map() :: #{ChannelID :: binary() := router_channel:channel()}.
+-type backoff_map() :: #{ChannelID :: binary() := {backoff:backoff(), reference()}}.
+
 -record(state, {
     chain = blockchain:blockchain(),
     event_mgr :: pid(),
     device_worker :: pid(),
     device :: router_device:device(),
-    channels = #{} :: map(),
-    channels_backoffs = #{} :: map(),
+    channels = #{} :: channel_map(),
+    channels_backoffs = #{} :: backoff_map(),
     data_cache = #{} :: #{router_utils:uuid_v4() => #{libp2p_crypto:pubkey_bin() => #data_cache{}}}
 }).
 
@@ -646,8 +649,8 @@ send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain) ->
     ok = router_channel:handle_uplink(EventMgrRef, Map, UUID),
     {ok, Map}.
 
--spec start_channel(pid(), router_channel:channel(), router_device:device(), map()) ->
-    {ok, map()} | {error, any(), map()}.
+-spec start_channel(pid(), router_channel:channel(), router_device:device(), backoff_map()) ->
+    {ok, backoff_map()} | {error, any(), backoff_map()}.
 start_channel(EventMgrRef, Channel, Device, Backoffs0) ->
     ChannelID = router_channel:unique_id(Channel),
     ChannelName = router_channel:name(Channel),
@@ -669,8 +672,8 @@ start_channel(EventMgrRef, Channel, Device, Backoffs0) ->
             {error, Reason, Backoffs1}
     end.
 
--spec update_channel(pid(), router_channel:channel(), router_device:device(), map()) ->
-    {ok, map()} | {error, any(), map()}.
+-spec update_channel(pid(), router_channel:channel(), router_device:device(), backoff_map()) ->
+    {ok, backoff_map()} | {error, any(), backoff_map()}.
 update_channel(EventMgrRef, Channel, Device, Backoffs0) ->
     ChannelID = router_channel:unique_id(Channel),
     ChannelName = router_channel:name(Channel),
@@ -712,7 +715,7 @@ maybe_start_decoder(Channel) ->
             end
     end.
 
--spec remove_old_channels(pid(), map(), map()) -> map().
+-spec remove_old_channels(pid(), channel_map(), channel_map()) -> channel_map().
 remove_old_channels(EventMgrRef, APIChannels, Channels) ->
     maps:filter(
         fun(ChannelID, Channel) ->
@@ -757,14 +760,14 @@ report_integration_error(Device, Description, Channel) ->
         ChannelInfo
     ).
 
--spec backoff_succeed(binary(), map()) -> map().
+-spec backoff_succeed(binary(), backoff_map()) -> backoff_map().
 backoff_succeed(ChannelID, Backoffs0) ->
     {Backoff, TimerRef} = maps:get(ChannelID, Backoffs0, ?BACKOFF_INIT),
     _ = erlang:cancel_timer(TimerRef),
     {_Delay, NewBackoff} = backoff:succeed(Backoff),
     maps:put(ChannelID, {NewBackoff, erlang:make_ref()}, Backoffs0).
 
--spec backoff_fail(binary(), map(), tuple()) -> {integer(), map()}.
+-spec backoff_fail(binary(), backoff_map(), tuple()) -> {integer(), backoff_map()}.
 backoff_fail(ChannelID, Backoffs0, ScheduleMessage) ->
     {Backoff0, TimerRef0} = maps:get(ChannelID, Backoffs0, ?BACKOFF_INIT),
     _ = erlang:cancel_timer(TimerRef0),

--- a/src/router_utils.erl
+++ b/src/router_utils.erl
@@ -30,7 +30,8 @@
     maybe_update_trace/1,
     mtype_to_ack/1,
     frame_timeout/0,
-    join_timeout/0
+    join_timeout/0,
+    get_env_int/2
 ]).
 
 -type uuid_v4() :: binary().
@@ -636,16 +637,16 @@ mtype_to_ack(_) -> 0.
 
 -spec frame_timeout() -> non_neg_integer().
 frame_timeout() ->
-    case application:get_env(router, frame_timeout, ?FRAME_TIMEOUT) of
-        [] -> ?FRAME_TIMEOUT;
-        Str when is_list(Str) -> erlang:list_to_integer(Str);
-        I -> I
-    end.
+    get_env_int(frame_timeout, ?FRAME_TIMEOUT).
 
 -spec join_timeout() -> non_neg_integer().
 join_timeout() ->
-    case application:get_env(router, join_timeout, ?JOIN_TIMEOUT) of
-        [] -> ?JOIN_TIMEOUT;
+    get_env_int(join_timeout, ?JOIN_TIMEOUT).
+
+-spec get_env_int(atom(), integer()) -> integer().
+get_env_int(Key, Default) ->
+    case application:get_env(router, Key, Default) of
+        [] -> Default;
         Str when is_list(Str) -> erlang:list_to_integer(Str);
         I -> I
     end.


### PR DESCRIPTION
When removing channels because the API has told us they should no longer exist, make sure we remove the backoffs with them.

ref: #458 