### PR TITLE
Add `rx_delay` from Console to LoRaWAN config

### DIFF
--- a/include/lorawan_db.hrl
+++ b/include/lorawan_db.hrl
@@ -124,7 +124,7 @@
     % requested after join
     adr_set :: adr_config(),
     max_datr :: 'undefined' | number(),
-    dcycle_set :: integer(),
+    dcycle_set :: undefined | integer(),
     % requested
     rxwin_set :: rxwin_config(),
     request_devstat :: boolean()
@@ -172,7 +172,7 @@
     adr_use :: adr_config(),
     % last request failed
     adr_failed = [] :: [binary()],
-    dcycle_use :: integer(),
+    dcycle_use :: undefined | integer(),
     % used
     rxwin_use :: rxwin_config(),
     % last request failed

--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -975,28 +975,32 @@ json_device_to_record(JSONDevice, ignore_meta_defaults) ->
     json_device_to_record(
         JSONDevice,
         _IgnoreADRMeta = undefined,
-        _IgnoreUS915CFListMeta = undefined
+        _IgnoreUS915CFListMeta = undefined,
+        _RxDelayDefault = undefined
     );
 json_device_to_record(JSONDevice, use_meta_defaults) ->
     json_device_to_record(
         JSONDevice,
         _ADRDefault = false,
-        _US915CFListDefault = false
+        _US915CFListDefault = false,
+        _RxDelayDefault = 0
     ).
 
 -spec json_device_to_record(
     JSONDevice :: map(),
     ADRDefault :: undefined | boolean(),
-    US915CFListDefault :: undefined | boolean()
+    US915CFListDefault :: undefined | boolean(),
+    RxDelayDefault :: undefined | 0..15
 ) -> router_device:device().
-json_device_to_record(JSONDevice, ADRDefault, US915CFListDefault) ->
+json_device_to_record(JSONDevice, ADRDefault, US915CFListDefault, RxDelayDefault) ->
     ID = kvc:path([<<"id">>], JSONDevice),
     Metadata = #{
         labels => kvc:path([<<"labels">>], JSONDevice, undefined),
         organization_id => kvc:path([<<"organization_id">>], JSONDevice, undefined),
         multi_buy => kvc:path([<<"multi_buy">>], JSONDevice, undefined),
         adr_allowed => kvc:path([<<"adr_allowed">>], JSONDevice, ADRDefault),
-        cf_list_enabled => kvc:path([<<"cf_list_enabled">>], JSONDevice, US915CFListDefault)
+        cf_list_enabled => kvc:path([<<"cf_list_enabled">>], JSONDevice, US915CFListDefault),
+        rx_delay => kvc:path([<<"rx_delay">>], JSONDevice, RxDelayDefault)
     },
     DeviceUpdates = [
         {name, kvc:path([<<"name">>], JSONDevice)},

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -474,8 +474,8 @@ packet_offer_(Offer, Pid, Chain) ->
             case bloom:set(BFRef, PHash) of
                 true ->
                     case lookup_replay(PHash) of
-                        {ok, DeviceID, PackeTime} ->
-                            case erlang:system_time(millisecond) - PackeTime > ?RX2_WINDOW of
+                        {ok, DeviceID, PacketTime} ->
+                            case erlang:system_time(millisecond) - PacketTime > ?RX2_WINDOW of
                                 true ->
                                     %% Buying replay packet
                                     lager:debug(

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -929,7 +929,7 @@ handle_info(
         freq = TxFreq
     } = lorawan_mac_region:join1_window(
         Region,
-        maps:get(rx_delay, router_device:metadata(Device0), 0),
+        0,
         packet_to_rxq(Packet)
     ),
     Rx2 = join2_from_packet(Region, Packet),
@@ -1650,13 +1650,20 @@ handle_frame_timeout(
                 },
                 Device0
             ),
+            Delay =
+                case lists:member(rx_timing_setup_ans, Frame#frame.fopts) of
+                    true ->
+                        maps:get(rx_delay, router_device:metadata(Device0), 0);
+                    false ->
+                        0
+                end,
             #txq{
                 time = TxTime,
                 datr = TxDataRate,
                 freq = TxFreq
             } = lorawan_mac_region:rx1_or_rx2_window(
                 Region,
-                maps:get(rx_delay, router_device:metadata(Device0), 0),
+                Delay,
                 0,
                 packet_to_rxq(Packet0)
             ),
@@ -1749,13 +1756,20 @@ handle_frame_timeout(
         },
         Device0
     ),
+    Delay =
+        case lists:member(rx_timing_setup_ans, Frame#frame.fopts) of
+            true ->
+                maps:get(rx_delay, router_device:metadata(Device0), 0);
+            false ->
+                0
+        end,
     #txq{
         time = TxTime,
         datr = TxDataRate,
         freq = TxFreq
     } = lorawan_mac_region:rx1_or_rx2_window(
         Region,
-        maps:get(rx_delay, router_device:metadata(Device0), 0),
+        Delay,
         0,
         packet_to_rxq(Packet0)
     ),

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1655,7 +1655,7 @@ handle_frame_timeout(
                 case
                     lists:member(rx_timing_setup_ans, Frame#frame.fopts) orelse
                         maps:get(
-                            rx_delay_timing_ans_device_ack,
+                            ?RX_DELAY_TIMING_ANS_DEVICE_ACK,
                             router_device:metadata(Device0),
                             false
                         )
@@ -1689,7 +1689,7 @@ handle_frame_timeout(
                 {fcntdown, (FCntDown + 1)},
                 {metadata,
                     maps:put(
-                        rx_delay_timing_ans_device_ack,
+                        ?RX_DELAY_TIMING_ANS_DEVICE_ACK,
                         RXTimingSetupAns,
                         router_device:metadata(Device0)
                     )}
@@ -1774,7 +1774,7 @@ handle_frame_timeout(
         case
             lists:member(rx_timing_setup_ans, Frame#frame.fopts) orelse
                 maps:get(
-                    rx_delay_timing_ans_device_ack,
+                    ?RX_DELAY_TIMING_ANS_DEVICE_ACK,
                     router_device:metadata(Device0),
                     false
                 )
@@ -1807,7 +1807,7 @@ handle_frame_timeout(
     DeviceUpdateMetadata =
         {metadata,
             maps:put(
-                rx_delay_timing_ans_device_ack,
+                ?RX_DELAY_TIMING_ANS_DEVICE_ACK,
                 RXTimingSetupAns,
                 router_device:metadata(Device0)
             )},

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -489,11 +489,11 @@ tx_window(Window, #rxq{tmms = Stamp} = Rxq, TxQ) when is_integer(Stamp) ->
 %% LoRaWAN Link Layer v1.0.4 spec, Section 5.7 Setting Delay between TX and RX,
 %% Table 45 and "RX2 always opens 1s after RX1."
 -spec tx_window(atom(), #rxq{}, #txq{}, number()) -> #txq{}.
-tx_window(join1_window, #rxq{tmms = Stamp}, TxQ, _RxDelaySeconds) when is_integer(Stamp) ->
-    Delay = get_window(join1_window),
+tx_window(?JOIN1_WINDOW, #rxq{tmms = Stamp}, TxQ, _RxDelaySeconds) when is_integer(Stamp) ->
+    Delay = get_window(?JOIN1_WINDOW),
     TxQ#txq{time = Stamp + Delay};
-tx_window(join2_window, #rxq{tmms = Stamp}, TxQ, _RxDelaySeconds) when is_integer(Stamp) ->
-    Delay = get_window(join2_window),
+tx_window(?JOIN2_WINDOW, #rxq{tmms = Stamp}, TxQ, _RxDelaySeconds) when is_integer(Stamp) ->
+    Delay = get_window(?JOIN2_WINDOW),
     TxQ#txq{time = Stamp + Delay};
 tx_window(Window, #rxq{tmms = Stamp}, TxQ, RxDelaySeconds) when is_integer(Stamp) ->
     %% TODO check if the time is a datetime, which would imply gps timebase
@@ -503,7 +503,7 @@ tx_window(Window, #rxq{tmms = Stamp}, TxQ, RxDelaySeconds) when is_integer(Stamp
                 get_window(Window);
             N ->
                 case Window of
-                    rx2_window ->
+                    ?RX2_WINDOW ->
                         N * 1000000 + 1000000;
                     _ ->
                         N * 1000000

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -484,6 +484,12 @@ tx_window(Window, #rxq{tmms = Stamp}, TxQ) when is_integer(Stamp) ->
 %% LoRaWAN Link Layer v1.0.4 spec, Section 5.7 Setting Delay between TX and RX,
 %% Table 45 and "RX2 always opens 1s after RX1."
 -spec tx_window(atom(), #rxq{}, #txq{}, number()) -> #txq{}.
+tx_window(join1_window, #rxq{tmms = Stamp}, TxQ, _RxDelaySeconds) when is_integer(Stamp) ->
+    Delay = get_window(join1_window),
+    TxQ#txq{time = Stamp + Delay};
+tx_window(join2_window, #rxq{tmms = Stamp}, TxQ, _RxDelaySeconds) when is_integer(Stamp) ->
+    Delay = get_window(join2_window),
+    TxQ#txq{time = Stamp + Delay};
 tx_window(Window, #rxq{tmms = Stamp}, TxQ, RxDelaySeconds) when is_integer(Stamp) ->
     %% TODO check if the time is a datetime, which would imply gps timebase
     Delay =
@@ -492,8 +498,6 @@ tx_window(Window, #rxq{tmms = Stamp}, TxQ, RxDelaySeconds) when is_integer(Stamp
                 get_window(Window);
             N ->
                 case Window of
-                    join2_window ->
-                        N * 1000000 + 1000000;
                     rx2_window ->
                         N * 1000000 + 1000000;
                     _ ->

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -141,11 +141,11 @@
 %% Region Wrapped Receive Window Functions
 %% ------------------------------------------------------------------
 
--spec join1_window(atom(), integer(), #rxq{}) -> #txq{}.
-join1_window(Region, _Delay, RxQ) ->
+-spec join1_window(atom(), non_neg_integer(), #rxq{}) -> #txq{}.
+join1_window(Region, DelaySeconds, RxQ) ->
     TopLevelRegion = top_level_region(Region),
     TxQ = rx1_rf(TopLevelRegion, RxQ, 0),
-    tx_window(?FUNCTION_NAME, RxQ, TxQ).
+    tx_window(?FUNCTION_NAME, RxQ, TxQ, DelaySeconds).
 
 -spec join2_window(atom(), #rxq{}) -> #txq{}.
 join2_window(Region, RxQ) ->
@@ -154,10 +154,10 @@ join2_window(Region, RxQ) ->
     tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
 -spec rx1_window(atom(), number(), number(), #rxq{}) -> #txq{}.
-rx1_window(Region, _Delay, Offset, RxQ) ->
+rx1_window(Region, DelaySeconds, Offset, RxQ) ->
     TopLevelRegion = top_level_region(Region),
     TxQ = rx1_rf(TopLevelRegion, RxQ, Offset),
-    tx_window(?FUNCTION_NAME, RxQ, TxQ).
+    tx_window(?FUNCTION_NAME, RxQ, TxQ, DelaySeconds).
 
 -spec rx2_window(atom(), #rxq{}) -> #txq{}.
 rx2_window(Region, RxQ) ->
@@ -165,7 +165,7 @@ rx2_window(Region, RxQ) ->
     TxQ = rx2_rf(TopLevelRegion, RxQ),
     tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
--spec rx1_or_rx2_window(atom(), number(), number(), #rxq{}) -> #txq{}.
+-spec rx1_or_rx2_window(atom(), non_neg_integer(), number(), #rxq{}) -> #txq{}.
 rx1_or_rx2_window(Region, Delay, Offset, RxQ) ->
     TopLevelRegion = top_level_region(Region),
     case TopLevelRegion of
@@ -471,7 +471,7 @@ tx_offset(Region, RxQ, Freq, Offset) ->
     DataRate = datar_to_down(Region, RxQ#rxq.datr, Offset),
     #txq{freq = Freq, datr = DataRate, codr = RxQ#rxq.codr, time = RxQ#rxq.time}.
 
--spec get_window(atom()) -> number().
+-spec get_window(atom()) -> non_neg_integer().
 get_window(join1_window) -> 5000000;
 get_window(join2_window) -> 6000000;
 get_window(rx1_window) -> 1000000;
@@ -479,9 +479,20 @@ get_window(rx2_window) -> 2000000.
 
 -spec tx_window(atom(), #rxq{}, #txq{}) -> #txq{}.
 tx_window(Window, #rxq{tmms = Stamp}, TxQ) when is_integer(Stamp) ->
+    tx_window(Window, #rxq{tmms = Stamp}, TxQ, 0).
+
+-spec tx_window(atom(), #rxq{}, #txq{}, non_neg_integer()) -> #txq{}.
+tx_window(Window, #rxq{tmms = Stamp}, TxQ, RxDelaySeconds) when is_integer(Stamp) ->
     %% TODO check if the time is a datetime, which would imply gps timebase
-    %% TODO handle rx delay here
-    Delay = get_window(Window),
+    Delay =
+        case RxDelaySeconds of
+            %% LoRaWAN Link Layer v1.0.4 spec,
+            %% Section 5.7 Setting Delay between TX and RX, Table 45.
+            N when N < 2 ->
+                get_window(Window);
+            N ->
+                get_window(Window) + N * 1000000
+        end,
     TxQ#txq{time = Stamp + Delay}.
 
 %% ------------------------------------------------------------------

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -141,7 +141,7 @@
 %% Region Wrapped Receive Window Functions
 %% ------------------------------------------------------------------
 
--spec join1_window(atom(), non_neg_integer(), #rxq{}) -> #txq{}.
+-spec join1_window(atom(), integer(), #rxq{}) -> #txq{}.
 join1_window(Region, DelaySeconds, RxQ) ->
     TopLevelRegion = top_level_region(Region),
     TxQ = rx1_rf(TopLevelRegion, RxQ, 0),
@@ -165,7 +165,7 @@ rx2_window(Region, RxQ) ->
     TxQ = rx2_rf(TopLevelRegion, RxQ),
     tx_window(?FUNCTION_NAME, RxQ, TxQ).
 
--spec rx1_or_rx2_window(atom(), non_neg_integer(), number(), #rxq{}) -> #txq{}.
+-spec rx1_or_rx2_window(atom(), number(), number(), #rxq{}) -> #txq{}.
 rx1_or_rx2_window(Region, Delay, Offset, RxQ) ->
     TopLevelRegion = top_level_region(Region),
     case TopLevelRegion of
@@ -471,7 +471,7 @@ tx_offset(Region, RxQ, Freq, Offset) ->
     DataRate = datar_to_down(Region, RxQ#rxq.datr, Offset),
     #txq{freq = Freq, datr = DataRate, codr = RxQ#rxq.codr, time = RxQ#rxq.time}.
 
--spec get_window(atom()) -> non_neg_integer().
+-spec get_window(atom()) -> number().
 get_window(join1_window) -> 5000000;
 get_window(join2_window) -> 6000000;
 get_window(rx1_window) -> 1000000;
@@ -481,7 +481,7 @@ get_window(rx2_window) -> 2000000.
 tx_window(Window, #rxq{tmms = Stamp}, TxQ) when is_integer(Stamp) ->
     tx_window(Window, #rxq{tmms = Stamp}, TxQ, 0).
 
--spec tx_window(atom(), #rxq{}, #txq{}, non_neg_integer()) -> #txq{}.
+-spec tx_window(atom(), #rxq{}, #txq{}, number()) -> #txq{}.
 tx_window(Window, #rxq{tmms = Stamp}, TxQ, RxDelaySeconds) when is_integer(Stamp) ->
     %% TODO check if the time is a datetime, which would imply gps timebase
     Delay =

--- a/src/lora/lorawan_utils.erl
+++ b/src/lora/lorawan_utils.erl
@@ -7,8 +7,6 @@
 %%%-------------------------------------------------------------------
 -module(lorawan_utils).
 
--dialyzer(no_match).
-
 -export([binary_to_hex/1, hex_to_binary/1, reverse/1]).
 -export([index_of/2]).
 -export([precise_universal_time/0, time_to_gps/0, time_to_gps/1, time_to_unix/0, time_to_unix/1]).
@@ -241,7 +239,6 @@ event_args(Event) when is_atom(Event) ->
 event_args(Event) when is_binary(Event) ->
     {Event, undefined}.
 
-inc(undefined) -> 1;
 inc(Num) -> Num + 1.
 
 -include_lib("eunit/include/eunit.hrl").

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -195,6 +195,11 @@ handle('GET', [<<"api">>, <<"router">>, <<"devices">>, DID], _Req, Args) ->
             [] -> false;
             [{adr_allowed, IS3}] -> IS3
         end,
+    RxDelay =
+        case ets:lookup(Tab, rx_delay) of
+            [] -> 0;
+            [{rx_delay, DelaySeconds}] -> DelaySeconds
+        end,
 
     Body = #{
         <<"id">> => DeviceID,
@@ -208,7 +213,8 @@ handle('GET', [<<"api">>, <<"router">>, <<"devices">>, DID], _Req, Args) ->
         <<"active">> => IsActive,
         <<"multi_buy">> => 1,
         <<"adr_allowed">> => ADRAllowed,
-        <<"cf_list_enabled">> => US915JoinAcceptCFListEnabled
+        <<"cf_list_enabled">> => US915JoinAcceptCFListEnabled,
+        <<"rx_delay">> => RxDelay
     },
     case NotFound of
         true ->

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -1784,6 +1784,7 @@ adr_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
@@ -1972,6 +1973,7 @@ adr_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
@@ -2168,6 +2170,7 @@ adr_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 3,
@@ -2318,6 +2321,7 @@ adr_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 4,
@@ -2579,7 +2583,7 @@ rx_delay_downlink_default_test(Config) ->
     %% Check that device is in cache now
     {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
-    {ok, DeviceID} = router_device:get_by_id(DB, CF, WorkerID),
+    {ok, Device} = router_device:get_by_id(DB, CF, WorkerID),
     {ok, _WorkerPid} = router_devices_sup:lookup_device_worker(WorkerID),
 
     %% TODO uncomment if testing against other regions.
@@ -2600,8 +2604,8 @@ rx_delay_downlink_default_test(Config) ->
             test_utils:frame_packet(
                 ?CONFIRMED_UP,
                 PubKeyBin,
-                router_device:nwk_s_key(DeviceID),
-                router_device:app_s_key(DeviceID),
+                router_device:nwk_s_key(Device),
+                router_device:app_s_key(Device),
                 0
             )},
     timer:sleep(router_utils:frame_timeout()),
@@ -2630,7 +2634,7 @@ rx_delay_ignored_by_device_downlink_test(Config) ->
     %% Check that device is in cache now
     {ok, DB, CF} = router_db:get_devices(),
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
-    {ok, DeviceID} = router_device:get_by_id(DB, CF, WorkerID),
+    {ok, Device} = router_device:get_by_id(DB, CF, WorkerID),
     {ok, _WorkerPid} = router_devices_sup:lookup_device_worker(WorkerID),
 
     %% TODO uncomment if testing against other regions.
@@ -2651,11 +2655,11 @@ rx_delay_ignored_by_device_downlink_test(Config) ->
             test_utils:frame_packet(
                 ?CONFIRMED_UP,
                 PubKeyBin,
-                router_device:nwk_s_key(DeviceID),
-                router_device:app_s_key(DeviceID),
-                0,
-                #{}
+                router_device:nwk_s_key(Device),
+                router_device:app_s_key(Device),
+                0
                 %% Test case should fail if this is uncommented
+                %% ,
                 %% #{
                 %%     fopts => [
                 %%        rx_timing_setup_ans

--- a/test/router_channel_azure_SUITE.erl
+++ b/test/router_channel_azure_SUITE.erl
@@ -138,14 +138,8 @@ azure_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here, but see next "metadata" below.
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,
@@ -286,6 +280,7 @@ azure_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_channel_azure_SUITE.erl
+++ b/test/router_channel_azure_SUITE.erl
@@ -143,7 +143,8 @@ azure_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -284,7 +285,8 @@ azure_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -201,7 +201,8 @@ inactive_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -351,7 +352,8 @@ inactive_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -196,14 +196,8 @@ inactive_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here, but see next "metadata" below.
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,
@@ -353,6 +347,7 @@ inactive_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,

--- a/test/router_channel_http_SUITE.erl
+++ b/test/router_channel_http_SUITE.erl
@@ -101,14 +101,8 @@ http_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here:
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,
@@ -241,14 +235,8 @@ http_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here:
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,
@@ -444,14 +432,8 @@ http_update_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here:
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,

--- a/test/router_channel_http_SUITE.erl
+++ b/test/router_channel_http_SUITE.erl
@@ -106,7 +106,8 @@ http_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -245,7 +246,8 @@ http_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -447,7 +449,8 @@ http_update_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -126,7 +126,8 @@ mqtt_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -275,7 +276,8 @@ mqtt_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -501,7 +503,8 @@ mqtt_update_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -664,7 +667,8 @@ mqtt_update_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -823,7 +827,8 @@ mqtt_update_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -121,14 +121,8 @@ mqtt_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here:
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,
@@ -277,6 +271,7 @@ mqtt_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
@@ -498,14 +493,8 @@ mqtt_update_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        %% Not all metadata is populated here, but see next "metadata" below.
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
         <<"payload">> => <<>>,
@@ -668,6 +657,7 @@ mqtt_update_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
@@ -828,6 +818,7 @@ mqtt_update_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -192,7 +192,8 @@ no_channel_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -193,6 +193,7 @@ no_channel_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_console_dc_tracker_SUITE.erl
+++ b/test/router_console_dc_tracker_SUITE.erl
@@ -103,7 +103,8 @@ dc_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -115,7 +115,8 @@ data_test_1(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => ReportedAtCheck,
@@ -252,7 +253,8 @@ data_test_2(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => ReportedAtCheck,
@@ -388,7 +390,8 @@ data_test_3(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => ReportedAtCheck,

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -103,7 +103,8 @@ decode_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -216,7 +217,8 @@ timeout_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -310,7 +312,8 @@ too_many_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -616,7 +616,8 @@ late_packet_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -183,7 +183,8 @@ route_packet(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -380,7 +380,8 @@ bad_fcnt_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => FCnt,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -131,7 +131,8 @@ device_worker_late_packet_double_charge_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -760,7 +761,8 @@ replay_uplink_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -815,7 +817,8 @@ replay_uplink_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -818,6 +818,7 @@ replay_uplink_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -159,7 +159,8 @@ disovery_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -227,7 +228,8 @@ disovery_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -315,7 +317,8 @@ disovery_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -397,7 +400,8 @@ fail_to_connect_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -229,6 +229,7 @@ disovery_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
@@ -318,6 +319,7 @@ disovery_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -298,7 +298,8 @@ test_downlink_message_for_channel(Config, DownlinkPayload, DownlinkMessage, Expe
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
         <<"reported_at">> => fun erlang:is_integer/1,

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -255,14 +255,7 @@ lw_join_test(Config) ->
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"dev_eui">> => lorawan_utils:binary_to_hex(?DEVEUI),
         <<"app_eui">> => lorawan_utils:binary_to_hex(?APPEUI),
-        <<"metadata">> => #{
-            <<"labels">> => ?CONSOLE_LABELS,
-            <<"organization_id">> => ?CONSOLE_ORG_ID,
-            <<"multi_buy">> => 1,
-            <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false,
-            <<"rx_delay">> => 0
-        },
+        <<"metadata">> => fun erlang:is_map/1,
         <<"fcnt">> => 1,
         <<"downlink_url">> => fun erlang:is_binary/1,
         <<"reported_at">> => fun erlang:is_integer/1,
@@ -429,6 +422,7 @@ lw_join_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_timing_ans_device_ack">> => false,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -260,7 +260,8 @@ lw_join_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
         <<"downlink_url">> => fun erlang:is_binary/1,
@@ -427,7 +428,8 @@ lw_join_test(Config) ->
             <<"organization_id">> => ?CONSOLE_ORG_ID,
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
-            <<"cf_list_enabled">> => false
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
         <<"downlink_url">> => fun erlang:is_binary/1,

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -22,6 +22,7 @@
     wait_state_channel_message/3,
     wait_state_channel_message/8,
     wait_organizations_burned/1,
+    wait_state_channel_packet/2,
     join_payload/2,
     join_packet/3, join_packet/4,
     join_device/1, join_device/2,
@@ -661,6 +662,44 @@ wait_state_channel_message(Msg, Device, FrameData, Type, FPending, Ack, Fport, F
             ct:pal("wait_state_channel_message stacktrace ~p~n", [{_Reason, _Stacktrace}]),
             ct:fail("wait_state_channel_message failed")
     end.
+
+wait_state_channel_packet(Timeout, _PubKeyBin) ->
+    try
+        receive
+            {client_data, _, Data} ->
+                try
+                    blockchain_state_channel_v1_pb:decode_msg(
+                        Data,
+                        blockchain_state_channel_message_v1_pb
+                    )
+                of
+                    #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
+                        case Resp of
+                            #blockchain_state_channel_response_v1_pb{
+                                accepted = true,
+                                downlink = Packet
+                            } ->
+                                {ok, Packet};
+                            _ ->
+                                {error, Resp}
+                        end;
+                    _Else ->
+                        ct:fail("wait_state_channel_packet with frame wrong message ~p ", [_Else])
+                catch
+                    _E:_R ->
+                        ct:fail("wait_state_channel_packet with frame failed to decode ~p ~p", [
+                            Data,
+                            {_E, _R}
+                        ])
+                end
+        after Timeout -> ct:fail("wait_state_channel_packet with frame timeout")
+        end
+    catch
+        _Class:_Reason:_Stacktrace ->
+            ct:pal("wait_state_channel_packet with frame stacktrace ~p~n", [{_Reason, _Stacktrace}]),
+            ct:fail("wait_state_channel_packet with frame failed")
+    end.
+
 
 wait_organizations_burned(Expected) ->
     try

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -22,7 +22,7 @@
     wait_state_channel_message/3,
     wait_state_channel_message/8,
     wait_organizations_burned/1,
-    wait_state_channel_packet/2,
+    wait_state_channel_packet/1,
     join_payload/2,
     join_packet/3, join_packet/4,
     join_device/1, join_device/2,
@@ -663,7 +663,7 @@ wait_state_channel_message(Msg, Device, FrameData, Type, FPending, Ack, Fport, F
             ct:fail("wait_state_channel_message failed")
     end.
 
-wait_state_channel_packet(Timeout, _PubKeyBin) ->
+wait_state_channel_packet(Timeout) ->
     try
         receive
             {client_data, _, Data} ->
@@ -699,7 +699,6 @@ wait_state_channel_packet(Timeout, _PubKeyBin) ->
             ct:pal("wait_state_channel_packet with frame stacktrace ~p~n", [{_Reason, _Stacktrace}]),
             ct:fail("wait_state_channel_packet with frame failed")
     end.
-
 
 wait_organizations_burned(Expected) ->
     try


### PR DESCRIPTION
- This should resolve issue #531
- This will assist devices in regions where internet backbone latency contributes to timing issues; e.g., AU->US
- For this feature to be fully function, it is blocked by Console [PR#952](https://github.com/helium/console/pull/952)
