### PR TITLE
issue #535 - chmask little endian

### DIFF
--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -1295,7 +1295,7 @@ bits_test_() ->
         ),
         ?_assertEqual(
             [
-                {link_adr_req, datar_to_dr('US915', <<"SF12BW500">>), 20, 2, 7, 0},
+                {link_adr_req, datar_to_dr('US915', <<"SF12BW500">>), 20, 512, 7, 0},
                 {link_adr_req, datar_to_dr('US915', <<"SF12BW500">>), 20, 255, 0, 0}
             ],
             set_channels('US915', {20, <<"SF12BW500">>, [{8, 15}, {65, 65}]}, [])


### PR DESCRIPTION
Per the LoRaWAN 1.0.4 spec:
> The octet order for all multi-octet fields SHALL be little endian.

The original build_bin function builds a variable length byte array memory structure which is big endian by its nature.  The spec requires little endian for all multi-octet fields.  In the chmask case the chmask is always a u16, which is stored little-endian.

Rename build_bin to build_chmask.  It returns a non_neg_integer.  The original code will see a big-endian value.  Swap bytes and transform to little-endian value.

Update and add additional eunit tests to validate all edge cases.