### PR TITLE
fix ct test for #535

### DIFF
--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -568,7 +568,7 @@ lw_join_test(Config) ->
         {channel_mask, Mask} ->
             case Region of
                 'US915' ->
-                    ExpectedMask = lists:seq(8, 15),
+                    ExpectedMask = lists:seq(0, 7),
                     Mask = ExpectedMask;
                 _ ->
                     ct:pal("Mask is ~p", [Mask]),

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -569,7 +569,7 @@ lw_join_test(Config) ->
             case Region of
                 'US915' ->
                     ExpectedMask = lists:seq(0, 7),
-                    Mask = ExpectedMask;
+                    ?assertEqual(ExpectedMask, Mask);
                 _ ->
                     ct:pal("Mask is ~p", [Mask]),
                     ok


### PR DESCRIPTION
CT test is broken

%%% router_lorawan_SUITE ==> US915.lw_join_test: FAILED
%%% router_lorawan_SUITE ==>
Failure/Error: ?assertEqual([8,9,10,11,12,13,14,15], Mask)
  expected: [8,9,10,11,12,13,14,15]
       got: [0,1,2,3,4,5,6,7]
      line: 572

We changed the mask encoding from big-endian to little-endian.  This would change the mask from 0xF0 to 0x0F.  Thus the CT test should be modified to match 0..7.