### PR TITLE
Add grpc connections count metric

### DIFF
--- a/include/metrics.hrl
+++ b/include/metrics.hrl
@@ -22,6 +22,7 @@
 -define(METRICS_VM_PROC_Q, "router_vm_process_queue").
 -define(METRICS_VM_ETS_MEMORY, "router_vm_ets_memory").
 -define(METRICS_XOR_FILTER, "router_xor_filter").
+-define(METRICS_GRPC_CONNECTION_COUNT, "router_grpc_connection_count").
 
 -define(METRICS, [
     {?METRICS_DC, prometheus_gauge, [], "Active State Channel balance"},
@@ -46,5 +47,6 @@
     {?METRICS_VM_CPU, prometheus_gauge, [cpu], "Router CPU usage"},
     {?METRICS_VM_PROC_Q, prometheus_gauge, [name], "Router process queue"},
     {?METRICS_VM_ETS_MEMORY, prometheus_gauge, [name], "Router ets memory"},
-    {?METRICS_XOR_FILTER, prometheus_gauge, [], "Router XOR Filter udpates"}
+    {?METRICS_XOR_FILTER, prometheus_gauge, [], "Router XOR Filter udpates"},
+    {?METRICS_GRPC_CONNECTION_COUNT, prometheus_gauge, [], "Number of active GRPC Connections"}
 ]).

--- a/test/router_metrics_SUITE.erl
+++ b/test/router_metrics_SUITE.erl
@@ -96,4 +96,7 @@ metrics_test(Config) ->
     ?assert(BlockAge > StartTime andalso BlockAge < erlang:system_time(seconds)),
 
     ?assert(prometheus_gauge:value(?METRICS_VM_CPU, [1]) > 0),
+
+    %% Nothing was sent over grpc, make sure we can get a blank value
+    ?assertEqual(0, prometheus_gauge:value(?METRICS_GRPC_CONNECTION_COUNT)),
     ok.


### PR DESCRIPTION
We could do the same thing with supervisor:which_children, but the
acceptor_pool uses a different way to report workers than investigating
the supervision tree.