### PR TITLE
Mj/channel worker ci fix

### DIFF
--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -225,11 +225,14 @@ remove_channel_backoff_when_channel_changed_test(Config) ->
     {ok, DeviceWorkerPid} = router_devices_sup:maybe_start_worker(DeviceID, #{}),
     DeviceChannelsWorkerPid = test_utils:get_device_channels_worker(DeviceID),
 
+    %% Wait until Channels Worker is done processing channels
+    ok = test_utils:wait_until_no_messages(DeviceChannelsWorkerPid),
+
     %% Check that HTTP 1 is in there
     State0 = sys:get_state(DeviceChannelsWorkerPid),
     ChannelName = maps:get(<<"id">>, Channel),
     {Backoff0, _} = maps:get(ChannelName, State0#state.channels_backoffs),
-    ?assertEqual(BackoffMin * 2, backoff:get(Backoff0)),
+    ?assertMatch(BackoffTime when BackoffTime >= (BackoffMin * 2), backoff:get(Backoff0)),
 
     %% Console gets a message about the first failure
     test_utils:wait_for_console_event(<<"misc">>, #{
@@ -311,11 +314,14 @@ remove_channel_backoff_when_all_channels_removed_test(Config) ->
     {ok, DeviceWorkerPid} = router_devices_sup:maybe_start_worker(DeviceID, #{}),
     DeviceChannelsWorkerPid = test_utils:get_device_channels_worker(DeviceID),
 
+    %% Wait until Channels Worker is done processing channels
+    ok = test_utils:wait_until_no_messages(DeviceChannelsWorkerPid),
+
     %% Check that HTTP 1 is in there
     State0 = sys:get_state(DeviceChannelsWorkerPid),
     ChannelName = maps:get(<<"id">>, Channel),
     {Backoff0, _} = maps:get(ChannelName, State0#state.channels_backoffs),
-    ?assertEqual(BackoffMin * 2, backoff:get(Backoff0)),
+    ?assertMatch(BackoffTime when BackoffTime >= (BackoffMin * 2), backoff:get(Backoff0)),
 
     %% Console gets a message about the first failure
     test_utils:wait_for_console_event(<<"misc">>, #{

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -32,6 +32,7 @@
     deframe_join_packet/3,
     tmp_dir/0, tmp_dir/1,
     wait_until/1, wait_until/3,
+    wait_until_no_messages/1,
     is_jsx_encoded_map/1
 ]).
 
@@ -854,6 +855,16 @@ wait_until(Fun, Retry, Delay) when Retry > 0 ->
             timer:sleep(Delay),
             wait_until(Fun, Retry - 1, Delay)
     end.
+
+wait_until_no_messages(Pid) ->
+    wait_until(fun() ->
+        case erlang:process_info(Pid, message_queue_len) of
+            {message_queue_len, 0} ->
+                true;
+            {message_queue_len, N} ->
+                {messages_still_in_queue, N}
+        end
+    end).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions


### PR DESCRIPTION
To reproduce this failure I dropped my docker preferences down to the lowest available settings.

Our CI machine is given 2-cores.
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

The channels worker was not always able to make it through the messages we expected by the time we were grabbing it's state.