### PR TITLE
Add support for indexing into lists in mustache template

### DIFF
--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -58,7 +58,7 @@ maybe_apply_template(Template0, TemplateArgs) ->
     NormalMap = jsx:decode(jsx:encode(TemplateArgs), [return_maps]),
     DataFun = mk_data_fun(NormalMap, []),
     Template1 = replace_index_lookup_with_special_key(Template0),
-    try bbmustache:render(Template1, DataFun, [{key_type, binary}]) of
+    try bbmustache:render(Template1, DataFun, [{key_type, binary}, raise_on_context_miss]) of
         Res -> Res
     catch
         _E:_R ->

--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -66,7 +66,7 @@ maybe_apply_template(Template0, TemplateArgs) ->
                 _E,
                 _R,
                 Template1,
-                Data
+                NormalMap
             ]),
             <<"mustache template render failed">>
     end.

--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -172,7 +172,7 @@ replace_index_lookup_with_special_key(Template) ->
         [{return, binary}, global]
     ).
 
--spec index_list_of_maps(list(map())) -> map().
+-spec index_list_of_maps(list(map())) -> propslist:proplist().
 index_list_of_maps(LofM) ->
     [
         {integer_to_binary(Idx), V}

--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -56,9 +56,9 @@ maybe_apply_template(undefined, Data) ->
     jsx:encode(Data);
 maybe_apply_template(Template0, TemplateArgs) ->
     NormalMap = jsx:decode(jsx:encode(TemplateArgs), [return_maps]),
-    Data = mk_data_fun(NormalMap, []),
+    DataFun = mk_data_fun(NormalMap, []),
     Template1 = replace_index_lookup_with_special_key(Template0),
-    try bbmustache:render(Template1, Data, [{key_type, binary}]) of
+    try bbmustache:render(Template1, DataFun, [{key_type, binary}]) of
         Res -> Res
     catch
         _E:_R ->

--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -91,8 +91,13 @@ mk_data_fun(Data, FunStack) ->
                 error;
             {NewFunStack, <<?MUSTACHE_INDEX_LOOKUP, Key/binary>>} ->
                 case kvc:path(Key, Data) of
-                    [F | _] = Val when is_map(F) ->
-                        {ok, mk_data_fun(index_list_of_maps(Val), NewFunStack)};
+                    Val when is_list(Val) ->
+                        case io_lib:printable_unicode_list(Val) of
+                            true ->
+                                error;
+                            false ->
+                                {ok, mk_data_fun(index_list_of_maps(Val), NewFunStack)}
+                        end;
                     _ ->
                         error
                 end;


### PR DESCRIPTION
Fixes: #451 

When we come across a list where the first item is a map, we assume the
rest of the list is full of maps and we create a 0-indexed map of that
list.

This allows the renderer to continue looking for a value.
You cannot terminate a template value _on_ a list, and you cannot index
into lists of lists.