### PR TITLE
Join Accept with non-default rx_delay gets implicit ACK, per LoRaWAN spec

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1834,8 +1834,8 @@ maybe_update_rx_delay(APIDevice, Device) ->
                 maps:put(rx_delay_state, ?RX_DELAY_ESTABLISHED, Metadata0);
             false ->
                 %% Track requested value for new `rx_delay` without changing to it.
-                maps:put(rx_delay_state, ?RX_DELAY_CHANGE, Metadata0),
-                maps:put(new_rx_delay, NewRxDelay, Metadata0)
+                Map = #{rx_delay_state => ?RX_DELAY_CHANGE, new_rx_delay => NewRxDelay},
+                maps:merge(Metadata0, Map)
         end,
     Metadata1.
 

--- a/src/lora/lorawan_rxdelay.erl
+++ b/src/lora/lorawan_rxdelay.erl
@@ -1,0 +1,203 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Router LoRaWAN RxDelay ==
+%% See LoRaWAN Link Layer spec v1.0.4
+%% sections:
+%% - 3.3 Receive Windows
+%% - 4.2.1 Frame types (FType bit field), for Join Accept
+%% - 5.7 Setting Delay between TX and RX (RXTimingSetupReq, RXTimingSetupAns)
+%% - 6.2.6 Join-Accept frame, which includes RXDelay
+%% @end
+%%%-------------------------------------------------------------------
+-module(lorawan_rxdelay).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+-export([
+    get/1,
+    get/2,
+    bootstrap/1,
+    maybe_update/2,
+    adjust/1,
+    adjust/3
+]).
+
+-define(RX_DELAY_ESTABLISHED, rx_delay_established).
+-define(RX_DELAY_CHANGE, rx_delay_change).
+-define(RX_DELAY_REQUESTED, rx_delay_requested).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+-spec get(Metadata :: map()) -> Del :: non_neg_integer().
+get(Metadata) ->
+    ?MODULE:get(Metadata, 0).
+
+-spec get(Metadata :: map(), Default :: term()) -> Del :: non_neg_integer() | term().
+get(Metadata, Default) ->
+    maps:get(rx_delay_actual, Metadata, Default).
+
+-spec bootstrap(APIDevice :: router_device:device()) -> Metadata :: map().
+bootstrap(APIDevice) ->
+    %% Metadata here is ostensibly "settings" from Console/API:
+    Metadata = router_device:metadata(APIDevice),
+    %% The key `rx_delay' comes from Console/API for changing to that
+    %% value.  `rx_delay_actual' represents the value set in LoRaWAN
+    %% header during device Join and must go through request/answer
+    %% negotiation to be changed.
+    case maps:get(rx_delay, Metadata, 0) of
+        0 ->
+            %% Console always sends rx_delay via API, so default arm rarely gets used.
+            maps:put(rx_delay_state, ?RX_DELAY_ESTABLISHED, Metadata);
+        Del when Del =< 15 ->
+            Map = #{rx_delay_state => ?RX_DELAY_ESTABLISHED, rx_delay_actual => Del},
+            maps:merge(Metadata, Map)
+    end.
+
+-spec maybe_update(
+    APIDevice :: router_device:device(),
+    Device :: router_device:device()
+) -> Metadata :: map().
+maybe_update(APIDevice, Device) ->
+    %% Run after the value for `rx_delay` gets changed via Console.
+    %% Accommodate net-nil changes via Console as no-op; e.g., A -> B -> A.
+    Metadata0 = router_device:metadata(Device),
+    Actual = maps:get(rx_delay_actual, Metadata0, 0),
+    Requested = maps:get(rx_delay, router_device:metadata(APIDevice), Actual),
+    case Requested == Actual of
+        true ->
+            maps:put(rx_delay_state, ?RX_DELAY_ESTABLISHED, Metadata0);
+        false when Requested =< 15 ->
+            %% Track requested value for new `rx_delay` without actually changing to it.
+            maps:put(rx_delay_state, ?RX_DELAY_CHANGE, Metadata0)
+    end.
+
+-spec adjust(Device :: router_device:device()) -> Metadata :: map().
+adjust(Device) ->
+    {_, Metadata, _} = adjust(Device, [], []),
+    Metadata.
+
+-spec adjust(Device :: router_device:device(), UplinkFOpts :: list(), FOpts0 :: list()) ->
+    {RxDelay :: non_neg_integer(), Metadata1 :: map(), FOpts1 :: list()}.
+adjust(Device, UplinkFOpts, FOpts0) ->
+    Metadata0 = router_device:metadata(Device),
+    %% When state is undefined, it's probably a test that omits device_update():
+    State = maps:get(rx_delay_state, Metadata0, ?RX_DELAY_ESTABLISHED),
+    Actual = maps:get(rx_delay_actual, Metadata0, 0),
+    Answered = lists:member(rx_timing_setup_ans, UplinkFOpts),
+    %% Handle sequential changes to rx_delay; e.g, a previous change
+    %% was ack'd, and now there's potentially another new RxDelay value.
+    {RxDelay, Metadata1, FOpts1} =
+        case {State, Answered} of
+            %% Entering RX_DELAY_CHANGE state occurs in maybe_update_rx_delay().
+            {?RX_DELAY_ESTABLISHED, _} ->
+                {Actual, Metadata0, FOpts0};
+            {?RX_DELAY_CHANGE, _} ->
+                %% Console changed `rx_delay' value.
+                Requested = maps:get(rx_delay, Metadata0),
+                FOpts = [{rx_timing_setup_req, Requested} | FOpts0],
+                Metadata = maps:put(rx_delay_state, ?RX_DELAY_REQUESTED, Metadata0),
+                {Actual, Metadata, FOpts};
+            {?RX_DELAY_REQUESTED, false} ->
+                %% Router sent downlink request, Device has yet to ACK.
+                Requested = maps:get(rx_delay, Metadata0),
+                FOpts = [{rx_timing_setup_req, Requested} | FOpts0],
+                {Actual, Metadata0, FOpts};
+            {?RX_DELAY_REQUESTED, true} ->
+                %% Device responded with ACK, so Router can apply the requested rx_delay.
+                Requested = maps:get(rx_delay, Metadata0),
+                Map = #{rx_delay_actual => Requested, rx_delay_state => ?RX_DELAY_ESTABLISHED},
+                {Requested, maps:merge(Metadata0, Map), FOpts0}
+        end,
+    {RxDelay, Metadata1, FOpts1}.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+rx_delay_state_test() ->
+    ?assertEqual(default, get(#{foo => bar}, default)),
+    ?assertEqual(default, get(#{rx_delay => 15}, default)),
+    ?assertEqual(15, get(#{rx_delay_actual => 15}, default)),
+
+    %% Ensure only LoRaWAN-approved values used
+    Device = router_device:new(<<"foo">>),
+    ApiDeviceDelTooBig = router_device:metadata(#{rx_delay => 99}, Device),
+    ?assertError({case_clause, 99}, bootstrap(ApiDeviceDelTooBig)),
+
+    %% Bootstrapping state
+    ?assertEqual(#{rx_delay_state => ?RX_DELAY_ESTABLISHED}, bootstrap(Device)),
+    ApiDevice = router_device:metadata(#{rx_delay => 5}, Device),
+    ?assertEqual(
+        #{rx_delay_state => ?RX_DELAY_ESTABLISHED, rx_delay_actual => 5, rx_delay => 5},
+        bootstrap(ApiDevice)
+    ),
+
+    %% No net change yet, as LoRaWAN's RxDelay default is 0
+    ApiDevice0 = router_device:metadata(#{rx_delay => 0}, Device),
+    ?assertEqual(
+        #{rx_delay_state => ?RX_DELAY_ESTABLISHED},
+        maybe_update(ApiDevice0, Device)
+    ),
+
+    %% No net change when using non-default value for RxDelay.
+    Device1 = router_device:metadata(
+        #{rx_delay_state => ?RX_DELAY_ESTABLISHED, rx_delay_actual => 1},
+        Device
+    ),
+    ApiDevice1 = router_device:metadata(#{rx_delay => 1}, Device),
+    ?assertEqual(
+        #{rx_delay_state => ?RX_DELAY_ESTABLISHED, rx_delay_actual => 1},
+        maybe_update(ApiDevice1, Device1)
+    ),
+
+    %% Exercise default case to recover state
+    ?assertEqual({0, #{}, []}, adjust(Device, [], [])),
+    ?assertEqual(
+        {1, #{rx_delay_state => ?RX_DELAY_ESTABLISHED, rx_delay_actual => 1}, []},
+        adjust(Device1, [], [])
+    ),
+    ?assertEqual(
+        {1, #{rx_delay_state => ?RX_DELAY_ESTABLISHED, rx_delay_actual => 1}, []},
+        adjust(Device1, [rx_timing_setup_ans], [])
+    ),
+
+    %% Change delay value
+
+    ApiDevice2 = router_device:metadata(#{rx_delay => 2}, Device1),
+    ?assertEqual(
+        #{rx_delay_state => ?RX_DELAY_CHANGE, rx_delay_actual => 1},
+        maybe_update(ApiDevice2, Device1)
+    ),
+
+    Device2 = router_device:metadata(
+        #{
+            rx_delay_state => ?RX_DELAY_CHANGE,
+            rx_delay_actual => 2,
+            rx_delay => 3
+        },
+        Device
+    ),
+    Metadata2 = #{
+        rx_delay_state => ?RX_DELAY_REQUESTED,
+        rx_delay_actual => 2,
+        rx_delay => 3
+    },
+    ?assertEqual(
+        {2, Metadata2, [{rx_timing_setup_req, 3}]},
+        adjust(Device2, [], [])
+    ),
+    Device3 = router_device:metadata(Metadata2, Device),
+    Metadata3 = #{
+        rx_delay_state => ?RX_DELAY_ESTABLISHED,
+        rx_delay_actual => 3,
+        rx_delay => 3
+    },
+    ?assertEqual(
+        {3, Metadata3, []},
+        adjust(Device3, [rx_timing_setup_ans], [])
+    ),
+    ok.
+
+-endif.

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -2811,7 +2811,6 @@ rx_delay_accepted_by_device_downlink_test(Config) ->
 
     {ok, Packet} = test_utils:wait_state_channel_packet(1000),
 
-    %% check that the timestamp of the packet_pb is our default (1 second in the future)
     ?assertEqual(ExpectedRxDelay * 1000000, Packet#packet_pb.timestamp),
 
     %% Get API's `rx_delay` into Metadata:
@@ -2874,9 +2873,7 @@ rx_delay_continue_session_test(Config) ->
     Send(0, []),
     {ok, Packet0} = test_utils:wait_state_channel_packet(1000),
 
-    %% check that the timestamp of the packet_pb is our default (1 second in the future)
-    Timestamp0 = Packet0#packet_pb.timestamp,
-    ?assertEqual(ExpectedRxDelay * 1000000, Timestamp0),
+    ?assertEqual(ExpectedRxDelay * 1000000, Packet0#packet_pb.timestamp),
 
     gen_server:stop(WorkerPid0),
 
@@ -2887,9 +2884,7 @@ rx_delay_continue_session_test(Config) ->
 
     %% We haven't ack'd channel correction
 
-    %% check that the timestamp of the packet_pb is our default (1 second in the future)
-    Timestamp1 = Packet1#packet_pb.timestamp,
-    ?assertEqual(ExpectedRxDelay * 1000000, Timestamp1),
+    ?assertEqual(ExpectedRxDelay * 1000000, Packet1#packet_pb.timestamp),
 
     Channel = router_channel:new(
         <<"fake">>,
@@ -2904,8 +2899,7 @@ rx_delay_continue_session_test(Config) ->
 
     Send(2, []),
     {ok, Packet2} = test_utils:wait_state_channel_packet(1000),
-    Timestamp2 = Packet2#packet_pb.timestamp,
-    ?assertEqual(ExpectedRxDelay * 1000000, Timestamp2),
+    ?assertEqual(ExpectedRxDelay * 1000000, Packet2#packet_pb.timestamp),
 
     %% Re-join device, and change its RX_DELAY:
     %% 1. rejoin the device
@@ -2936,15 +2930,11 @@ rx_delay_continue_session_test(Config) ->
         timer:sleep(router_utils:frame_timeout())
     end,
 
-    %% TODO there is a join response but comes from PubKeyBin==undefined, why?
-    %% test_utils:wait_for_join_resp(PubKeyBin, AppKey, DevNonce),
     test_utils:ignore_messages(),
 
     Send1(0, []),
     {ok, Packet3} = test_utils:wait_state_channel_packet(1000),
-    Timestamp3 = Packet3#packet_pb.timestamp,
-    ?assertEqual(ExpectedRxDelay * 1000000, Timestamp3),
-    ?assertNotEqual(1000000, Timestamp3),
+    ?assertEqual(ExpectedRxDelay * 1000000, Packet3#packet_pb.timestamp),
     ok.
 
 rx_delay_change_during_session_test(Config) ->
@@ -2998,11 +2988,11 @@ rx_delay_change_during_session_test(Config) ->
                 )},
         timer:sleep(router_utils:frame_timeout())
     end,
+
     %% No rx_timing_setup_ans necessary upon Join, as join-accept flow is the ACK.
     Send(0, []),
     {ok, Packet0} = test_utils:wait_state_channel_packet(1000),
 
-    %% check that the timestamp of the packet_pb is our default (1 second in the future)
     ?assertEqual(ExpectedRxDelay1 * 1000000, Packet0#packet_pb.timestamp),
 
     %% Simulate a change in `rx_delay` value from Console:

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -2663,12 +2663,11 @@ rx_delay_downlink_default_test(Config) ->
     ?assertEqual(ExpectedRxDelay, maps:get(new_rx_delay, Metadata2)),
 
     %% Device ACK
-    Send(2, [rx_timing_setup_ans]),
+    Send(3, [rx_timing_setup_ans]),
 
     %% Handling `frame_timeout` calls adjust_rx_delay(), so state has been updated.
 
     %% Downlink after ACK uses new RxDelay
-    %% FIXME: times-out
     {ok, Packet3} = test_utils:wait_state_channel_packet(1000),
     ?assertEqual(ExpectedRxDelay * 1000000, Packet3#packet_pb.timestamp),
 

--- a/test/router_channel_azure_SUITE.erl
+++ b/test/router_channel_azure_SUITE.erl
@@ -280,7 +280,7 @@ azure_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -347,7 +347,7 @@ inactive_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -271,7 +271,7 @@ mqtt_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
@@ -657,7 +657,7 @@ mqtt_update_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
@@ -818,7 +818,7 @@ mqtt_update_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -193,7 +193,7 @@ no_channel_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_console_dc_tracker_SUITE.erl
+++ b/test/router_console_dc_tracker_SUITE.erl
@@ -104,6 +104,7 @@ dc_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -116,6 +116,7 @@ data_test_1(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
@@ -254,6 +255,7 @@ data_test_2(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
@@ -391,6 +393,7 @@ data_test_3(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -104,6 +104,7 @@ decode_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
@@ -218,6 +219,7 @@ timeout_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
@@ -313,6 +315,7 @@ too_many_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -623,6 +623,7 @@ late_packet_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -184,6 +184,7 @@ route_packet(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -381,6 +381,7 @@ bad_fcnt_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => FCnt,

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -818,7 +818,7 @@ replay_uplink_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -132,6 +132,7 @@ device_worker_late_packet_double_charge_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,
@@ -762,6 +763,7 @@ replay_uplink_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -160,6 +160,7 @@ disovery_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,
@@ -403,6 +404,7 @@ fail_to_connect_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -229,7 +229,7 @@ disovery_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,
@@ -319,7 +319,7 @@ disovery_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 1,

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -299,6 +299,7 @@ test_downlink_message_for_channel(Config, DownlinkPayload, DownlinkMessage, Expe
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 0,

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -422,7 +422,7 @@ lw_join_test(Config) ->
             <<"multi_buy">> => 1,
             <<"adr_allowed">> => false,
             <<"cf_list_enabled">> => false,
-            <<"rx_delay_timing_ans_device_ack">> => false,
+            <<"rx_delay_state">> => fun erlang:is_binary/1,
             <<"rx_delay">> => 0
         },
         <<"fcnt">> => 2,


### PR DESCRIPTION
This addresses issue #571.

Flow:
- `handle_join()` invokes the new `lorawan_rxdelay:bootstrap()` which establishes state and baseline Del value
- Existing `device_update()` and `get_device()` call the new `lorawan_rxdelay:maybe_update()`
- Handling of `join_timeout` and `handle_frame_timeout()` call `lorawan_rxdelay:adjust()`
- Only `Metadata` and downlink `FOpts` get modified by this flow

Changes to note while reviewing this PR:
- This introduces new states pertaining to `rx_delay`, which supersedes the earlier PR's state key/value pair.
   + *change* was requested via Console/API
   + *requested* device to use new Delay: `FOpts` set for downlink
   + new value has been *established* (ACK from device)
- `rx_delay_ignored_by_device_downlink_test()` has been replaced by:
`rx_delay_change_ignored_by_device_downlink_test()`
  + because a completed Join Accept implies that the device has accepted rx_delay.
- Changed some integer values for `ExpectedRxDelay` in tests to be easier to see when followed by trailing zeros for microseconds in test case failures; e.g., was 10, now 9