### PR TITLE
Add bin folder to path for access to router exe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ADD priv/genesis.${BUILD_NET} priv/genesis
 
 RUN ./rebar3 as ${BUILD_NET} release
 # add router to path for easy interactions
-ENV PATH=$PATH:_build/${BUILD_NET}/rel/router
+ENV PATH=$PATH:_build/${BUILD_NET}/rel/router/bin
 RUN ln -s /opt/router/_build/${BUILD_NET}/rel /opt/router/_build/default/rel
 RUN ln -s /opt/router/_build/default/rel/router/bin/router /opt/router-exec
 


### PR DESCRIPTION
`OCI runtime exec failed: exec failed: container_linux.go:367: starting container process caused: exec: "router": `

We were 1 folder away on the path 