### PR TITLE
Don't throw errors on context misses

### DIFF
--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -58,7 +58,7 @@ maybe_apply_template(Template0, TemplateArgs) ->
     NormalMap = jsx:decode(jsx:encode(TemplateArgs), [return_maps]),
     DataFun = mk_data_fun(NormalMap, []),
     Template1 = replace_index_lookup_with_special_key(Template0),
-    try bbmustache:render(Template1, DataFun, [{key_type, binary}, raise_on_context_miss]) of
+    try bbmustache:render(Template1, DataFun, [{key_type, binary}]) of
         Res -> Res
     catch
         _E:_R ->

--- a/src/channels/router_channel_utils.erl
+++ b/src/channels/router_channel_utils.erl
@@ -353,7 +353,7 @@ dot_syntax_test_() ->
             )},
         {"Out of bound access",
             ?_assertEqual(
-                <<"mustache template render failed">>,
+                <<"">>,
                 maybe_apply_template(<<"{{data.9999.value}}">>, BasicMap)
             )},
 


### PR DESCRIPTION
This might become a toggle in the future for people who would like to
debug their templates. But for now, we revert to previous working state
of affairs.