### PR TITLE
Encode URI when generating SAS token for azure

### DIFF
--- a/src/channels/router_azure_connection.erl
+++ b/src/channels/router_azure_connection.erl
@@ -1,5 +1,9 @@
 -module(router_azure_connection).
 
+%% TODO: Replace with `uri_string:quote/1' when it get's released.
+%% https://github.com/erlang/otp/pull/5700
+-compile({nowarn_deprecated_function, [{http_uri, encode, 1}]}).
+
 %% Create API
 -export([
     from_connection_string/2,
@@ -312,7 +316,10 @@ generate_mqtt_sas_token(#azure{mqtt_sas_uri = URI, policy_name = PName, policy_k
 
 -spec generate_sas_token(binary(), binary(), binary(), number()) -> binary().
 generate_sas_token(URI, PolicyName, PolicyKey, Expires) ->
-    EncodedURI = uri_string:transcode(URI, []),
+    %% TODO: Replace with `uri_string:quote/1' when it get's released.
+    %% https://github.com/erlang/otp/pull/5700
+    EncodedURI = http_uri:encode(URI),
+
     ExpireBin = erlang:integer_to_binary(erlang:system_time(seconds) + Expires),
     ToSign = <<EncodedURI/binary, "\n", ExpireBin/binary>>,
     Signed = base64:encode(crypto:mac(hmac, sha256, base64:decode(PolicyKey), ToSign)),


### PR DESCRIPTION
HTTP worked fine previously because the URI the token uses as a base
does not contain any special characters.

When connecting to MQTT, however, the URI contains the device-name after
a slash along with the api-version. The slashes are expected to be
url-encoded.

Until we upgrade OTP versions again, we're going to continune the use of
`http_uri:encode/1`.

refs:
`http_uri:encode/1` deprecation has been postponed to OTP/26
https://github.com/erlang/otp/pull/5696

OTP PR implementing `quote/unquote` in `uri_string`.
https://github.com/erlang/otp/pull/5700

OTP Issue no replacement for `http_uri:encode/1` in `uri_string`
https://github.com/erlang/otp/issues/5368