### PR TITLE
password uri uses the resource uri

### DIFF
--- a/src/channels/router_azure_connection.erl
+++ b/src/channels/router_azure_connection.erl
@@ -141,7 +141,7 @@ mqtt_connect(
         device_id = DeviceID
     } = Azure
 ) ->
-    Password = generate_mqtt_sas_token(Azure),
+    Password = generate_http_sas_token(Azure),
 
     {ok, Connection} = emqtt:start_link(#{
         clientid => DeviceID,


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-device

The host for connecting to the mqtt endpoint is not the same as http,
but the http is technically the resource uri in question.

Here's a point of confusion I can't quite wrap my head around.
When this integration was originally released, everything worked. 
But now we need an entirely different password?