### PR TITLE
unset devaddr when console device has app_eui or dev_eui changed

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -360,10 +360,25 @@ handle_cast(
             lager:info("device updated: ~p", [APIDevice]),
             router_device_channels_worker:refresh_channels(ChannelsWorker),
             IsActive = router_device:is_active(APIDevice),
+            Devaddr =
+                case
+                    {
+                        {router_device:app_eui(Device0), router_device:app_eui(APIDevice)},
+                        {router_device:dev_eui(Device0), router_device:dev_eui(APIDevice)}
+                    }
+                of
+                    {{App, App}, {Dev, Dev}} ->
+                        router_device:devaddr(Device0);
+                    _ ->
+                        lager:info("app_eui or dev_eui changed, unsetting devaddr"),
+                        undefined
+                end,
+
             DeviceUpdates = [
                 {name, router_device:name(APIDevice)},
                 {dev_eui, router_device:dev_eui(APIDevice)},
                 {app_eui, router_device:app_eui(APIDevice)},
+                {devaddr, Devaddr},
                 {metadata,
                     maps:merge(
                         lorawan_rxdelay:maybe_update(APIDevice, Device0),

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -200,13 +200,23 @@ handle('GET', [<<"api">>, <<"router">>, <<"devices">>, DID], _Req, Args) ->
             [] -> 0;
             [{rx_delay, DelaySeconds}] -> DelaySeconds
         end,
+    AppEUI =
+        case ets:lookup(Tab, app_eui) of
+            [] -> maps:get(app_eui, Args);
+            [{app_eui, EUI1}] -> EUI1
+        end,
+    DevEUI =
+        case ets:lookup(Tab, dev_eui) of
+            [] -> maps:get(dev_eui, Args);
+            [{dev_eui, EUI2}] -> EUI2
+        end,
 
     Body = #{
         <<"id">> => DeviceID,
         <<"name">> => ?CONSOLE_DEVICE_NAME,
         <<"app_key">> => lorawan_utils:binary_to_hex(maps:get(app_key, Args)),
-        <<"app_eui">> => lorawan_utils:binary_to_hex(maps:get(app_eui, Args)),
-        <<"dev_eui">> => lorawan_utils:binary_to_hex(maps:get(dev_eui, Args)),
+        <<"app_eui">> => lorawan_utils:binary_to_hex(AppEUI),
+        <<"dev_eui">> => lorawan_utils:binary_to_hex(DevEUI),
         <<"channels">> => Channels,
         <<"labels">> => ?CONSOLE_LABELS,
         <<"organization_id">> => ?CONSOLE_ORG_ID,

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -33,7 +33,8 @@
     tmp_dir/0, tmp_dir/1,
     wait_until/1, wait_until/3,
     wait_until_no_messages/1,
-    is_jsx_encoded_map/1
+    is_jsx_encoded_map/1,
+    ws_init/0
 ]).
 
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
@@ -997,3 +998,11 @@ deframe_join_packet(
 is_jsx_encoded_map([]) -> true;
 is_jsx_encoded_map(M) when is_map(M) -> true;
 is_jsx_encoded_map(_) -> false.
+
+-spec ws_init() -> {ok, pid()}.
+ws_init() ->
+    receive
+        {websocket_init, Pid} ->
+            {ok, Pid}
+    after 2500 -> ct:fail(websocket_init_timeout)
+    end.


### PR DESCRIPTION
This keeps router from buying packets for devices that have changed
their join credentials but have not turned off/on the device again to
make a new session.