### PR TITLE
Send DC balance to channels (#611)

### DIFF
--- a/src/device/router_device_channels_worker.erl
+++ b/src/device/router_device_channels_worker.erl
@@ -25,7 +25,7 @@
     handle_console_downlink/4,
     new_data_cache/8,
     refresh_channels/1,
-    frame_timeout/2
+    frame_timeout/3
 ]).
 
 %% ------------------------------------------------------------------
@@ -61,6 +61,7 @@
 
 -type channel_map() :: #{ChannelID :: binary() := router_channel:channel()}.
 -type backoff_map() :: #{ChannelID :: binary() := {backoff:backoff(), reference()}}.
+-type balance_nonce() :: {Balance :: integer(), Nonce :: integer}.
 
 -record(state, {
     chain = blockchain:blockchain(),
@@ -98,9 +99,9 @@ report_request(Pid, UUID, Channel, Map) ->
 report_response(Pid, UUID, Channel, Map) ->
     gen_server:cast(Pid, {report_response, UUID, Channel, Map}).
 
--spec frame_timeout(pid(), router_utils:uuid_v4()) -> ok.
-frame_timeout(Pid, UUID) ->
-    gen_server:cast(Pid, {frame_timeout, UUID}).
+-spec frame_timeout(pid(), router_utils:uuid_v4(), balance_nonce()) -> ok.
+frame_timeout(Pid, UUID, BalanceNonce) ->
+    gen_server:cast(Pid, {frame_timeout, UUID, BalanceNonce}).
 
 -spec handle_console_downlink(binary(), map(), router_channel:channel(), first | last) -> ok.
 handle_console_downlink(DeviceID, MapPayload, Channel, Position) ->
@@ -240,7 +241,7 @@ handle_cast(
     DataCache1 = maps:put(UUID, UUIDCache1, DataCache),
     {noreply, State#state{data_cache = DataCache1}};
 handle_cast(
-    {frame_timeout, UUID},
+    {frame_timeout, UUID, BalanceNonce},
     #state{
         data_cache = DataCache0,
         chain = Blockchain,
@@ -250,7 +251,7 @@ handle_cast(
 ) ->
     case maps:take(UUID, DataCache0) of
         {CachedData, DataCache1} ->
-            {ok, Map} = send_data_to_channel(CachedData, Device, EventMgrPid, Blockchain),
+            {ok, Map} = send_data_to_channel(CachedData, Device, EventMgrPid, Blockchain, BalanceNonce),
             lager:debug("frame_timeout for ~p data: ~p", [UUID, Map]),
             {noreply, State#state{data_cache = DataCache1}};
         error ->
@@ -620,9 +621,10 @@ send_join_to_channel(
     CachedData0 :: #{libp2p_crypto:pubkey_bin() => #data_cache{}},
     Device :: router_device:device(),
     EventMgrRef :: pid(),
-    Blockchain :: blockchain:blockchain()
+    Blockchain :: blockchain:blockchain(),
+    BalanceNonce :: balance_nonce()
 ) -> {ok, map()}.
-send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain) ->
+send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain, BalanceNonce) ->
     FormatHotspot = fun(DataCache) ->
         format_hotspot(DataCache, Blockchain)
     end,
@@ -633,6 +635,7 @@ send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain) ->
     [#data_cache{frame = Frame, time = Time, uuid = UUID, replay = Replay, packet = Packet} | _] =
         CachedData1,
     #frame{data = Payload, fport = Port, fcnt = FCnt, devaddr = DevAddr} = Frame,
+    {Balance, Nonce} = BalanceNonce,
     %% No touchy, this is set in STONE
     Map = #{
         type => uplink,
@@ -654,7 +657,11 @@ send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain) ->
                 _ -> Port
             end,
         devaddr => lorawan_utils:binary_to_hex(DevAddr),
-        hotspots => lists:map(FormatHotspot, CachedData1)
+        hotspots => lists:map(FormatHotspot, CachedData1),
+        dc => #{
+                <<"dc_balance">> => Balance,
+                <<"nonce">> => Nonce
+               }
     },
     ok = router_channel:handle_uplink(EventMgrRef, Map, UUID),
     {ok, Map}.

--- a/src/device/router_device_channels_worker.erl
+++ b/src/device/router_device_channels_worker.erl
@@ -251,7 +251,13 @@ handle_cast(
 ) ->
     case maps:take(UUID, DataCache0) of
         {CachedData, DataCache1} ->
-            {ok, Map} = send_data_to_channel(CachedData, Device, EventMgrPid, Blockchain, BalanceNonce),
+            {ok, Map} = send_data_to_channel(
+                CachedData,
+                Device,
+                EventMgrPid,
+                Blockchain,
+                BalanceNonce
+            ),
             lager:debug("frame_timeout for ~p data: ~p", [UUID, Map]),
             {noreply, State#state{data_cache = DataCache1}};
         error ->
@@ -659,9 +665,9 @@ send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain, BalanceNonce)
         devaddr => lorawan_utils:binary_to_hex(DevAddr),
         hotspots => lists:map(FormatHotspot, CachedData1),
         dc => #{
-                <<"dc_balance">> => Balance,
-                <<"nonce">> => Nonce
-               }
+            <<"dc_balance">> => Balance,
+            <<"nonce">> => Nonce
+        }
     },
     ok = router_channel:handle_uplink(EventMgrRef, Map, UUID),
     {ok, Map}.

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -824,7 +824,7 @@ handle_cast(
                             FCnt,
                             Timeout
                         ]),
-                        _ = erlang:send_after(Timeout, self(), {frame_timeout, FCnt, PacketTime}),
+                        _ = erlang:send_after(Timeout, self(), {frame_timeout, FCnt, PacketTime, BalanceNonce}),
                         {NewFrameCache#frame_cache.uuid, State#state{
                             device = Device2,
                             frame_cache = maps:put(FCnt, NewFrameCache, Cache0)
@@ -984,7 +984,7 @@ handle_info(
         join_cache = maps:remove(DevNonce, JoinCache)
     }};
 handle_info(
-    {frame_timeout, FCnt, PacketTime},
+    {frame_timeout, FCnt, PacketTime, BalanceNonce},
     #state{
         chain = Blockchain,
         db = DB,
@@ -1014,7 +1014,7 @@ handle_info(
     } = FrameCache,
     Cache1 = maps:remove(FCnt, Cache0),
     ok = router_device_multibuy:delete(blockchain_helium_packet_v1:packet_hash(Packet)),
-    ok = router_device_channels_worker:frame_timeout(ChannelsWorker, UUID),
+    ok = router_device_channels_worker:frame_timeout(ChannelsWorker, UUID, BalanceNonce),
     lager:debug("frame timeout for ~p / device ~p", [FCnt, lager:pr(Device0, router_device)]),
     {ADREngine1, ADRAdjustment} = maybe_track_adr_packet(Device0, ADREngine0, FrameCache),
     DeviceID = router_device:id(Device0),

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -824,7 +824,11 @@ handle_cast(
                             FCnt,
                             Timeout
                         ]),
-                        _ = erlang:send_after(Timeout, self(), {frame_timeout, FCnt, PacketTime, BalanceNonce}),
+                        _ = erlang:send_after(
+                            Timeout,
+                            self(),
+                            {frame_timeout, FCnt, PacketTime, BalanceNonce}
+                        ),
                         {NewFrameCache#frame_cache.uuid, State#state{
                             device = Device2,
                             frame_cache = maps:put(FCnt, NewFrameCache, Cache0)

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -295,9 +295,9 @@ dupes_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -1626,9 +1626,9 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Unconfirmed downlink sent to device
@@ -1821,9 +1821,9 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% ---------------------------------------------------------------
@@ -2015,9 +2015,9 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Sending Msg1 again because it was not acknowledged by the device
@@ -2215,9 +2215,9 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                              <<"dc_balance">> => fun erlang:is_integer/1,
-                              <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -2370,9 +2370,9 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -293,7 +293,11 @@ dupes_test(Config) ->
                 <<"lat">> => <<"unknown">>,
                 <<"long">> => <<"unknown">>
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -1620,7 +1624,11 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Unconfirmed downlink sent to device
@@ -1811,7 +1819,11 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% ---------------------------------------------------------------
@@ -2001,7 +2013,11 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Sending Msg1 again because it was not acknowledged by the device
@@ -2197,7 +2213,11 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                              <<"dc_balance">> => fun erlang:is_integer/1,
+                              <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -2348,7 +2368,11 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -220,7 +220,11 @@ inactive_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -372,7 +376,11 @@ inactive_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -222,9 +222,9 @@ inactive_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -378,9 +378,9 @@ inactive_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_channel_http_SUITE.erl
+++ b/test/router_channel_http_SUITE.erl
@@ -125,7 +125,11 @@ http_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -259,7 +263,11 @@ http_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -456,7 +464,11 @@ http_update_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -851,7 +863,11 @@ http_decoded_payload_test(Config) ->
         },
         <<"port">> => 1,
         <<"devaddr">> => '_',
-        <<"hotspots">> => fun erlang:is_list/1
+        <<"hotspots">> => fun erlang:is_list/1,
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_channel_http_SUITE.erl
+++ b/test/router_channel_http_SUITE.erl
@@ -127,9 +127,9 @@ http_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -265,9 +265,9 @@ http_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -466,9 +466,9 @@ http_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel
@@ -865,9 +865,9 @@ http_decoded_payload_test(Config) ->
         <<"devaddr">> => '_',
         <<"hotspots">> => fun erlang:is_list/1,
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_channel_iot_hub_SUITE.erl
+++ b/test/router_channel_iot_hub_SUITE.erl
@@ -168,7 +168,11 @@ iot_hub_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -311,7 +315,11 @@ iot_hub_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from MQTT channel

--- a/test/router_channel_iot_hub_SUITE.erl
+++ b/test/router_channel_iot_hub_SUITE.erl
@@ -170,9 +170,9 @@ iot_hub_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -317,9 +317,9 @@ iot_hub_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -141,9 +141,9 @@ mqtt_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -297,10 +297,9 @@ mqtt_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -523,10 +522,9 @@ mqtt_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -693,10 +691,9 @@ mqtt_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -865,10 +862,9 @@ mqtt_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from MQTT channel

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -139,7 +139,11 @@ mqtt_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -291,7 +295,12 @@ mqtt_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -512,7 +521,12 @@ mqtt_update_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -677,7 +691,12 @@ mqtt_update_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from MQTT channel
@@ -844,7 +863,12 @@ mqtt_update_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from MQTT channel

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -218,7 +218,12 @@ no_channel_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -220,10 +220,9 @@ no_channel_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_console_dc_tracker_SUITE.erl
+++ b/test/router_console_dc_tracker_SUITE.erl
@@ -143,7 +143,12 @@ dc_test(Config) ->
                 <<"lat">> => <<"unknown">>,
                 <<"long">> => <<"unknown">>
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_console_dc_tracker_SUITE.erl
+++ b/test/router_console_dc_tracker_SUITE.erl
@@ -145,10 +145,9 @@ dc_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -145,9 +145,9 @@ data_test_1(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     test_utils:wait_for_console_event_sub(<<"uplink_unconfirmed">>, #{
@@ -288,9 +288,9 @@ data_test_2(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% ---------------------------------------------------------------
@@ -430,9 +430,9 @@ data_test_3(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% ---------------------------------------------------------------

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -143,7 +143,11 @@ data_test_1(Config) ->
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     test_utils:wait_for_console_event_sub(<<"uplink_unconfirmed">>, #{
@@ -282,7 +286,11 @@ data_test_2(Config) ->
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% ---------------------------------------------------------------
@@ -420,7 +428,11 @@ data_test_3(Config) ->
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% ---------------------------------------------------------------

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -135,10 +135,9 @@ decode_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
     ok.
 
@@ -255,10 +254,9 @@ timeout_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     DecoderID = maps:get(<<"id">>, ?CONSOLE_DECODER),
@@ -356,10 +354,9 @@ too_many_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     DecoderID = maps:get(<<"id">>, ?CONSOLE_DECODER),

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -133,7 +133,12 @@ decode_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
     ok.
 
@@ -248,7 +253,12 @@ timeout_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     DecoderID = maps:get(<<"id">>, ?CONSOLE_DECODER),
@@ -344,7 +354,12 @@ too_many_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     DecoderID = maps:get(<<"id">>, ?CONSOLE_DECODER),

--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -662,7 +662,11 @@ late_packet_test(Config) ->
                 <<"lat">> => <<"unknown">>,
                 <<"long">> => <<"unknown">>
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
     }),
 
     %% Waiting for report channel status from HTTP channel from hotspots 1

--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -32,7 +32,8 @@
 -define(BACKOFF_MIN, timer:seconds(15)).
 -define(BACKOFF_MAX, timer:minutes(5)).
 -define(BACKOFF_INIT, {
-    backoff:type(backoff:init(?BACKOFF_MIN, ?BACKOFF_MAX), normal), erlang:make_ref()
+    backoff:type(backoff:init(?BACKOFF_MIN, ?BACKOFF_MAX), normal),
+    erlang:make_ref()
 }).
 
 -record(state, {
@@ -664,9 +665,9 @@ late_packet_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel from hotspots 1

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -163,7 +163,12 @@ route_packet(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     ok.

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -76,7 +76,7 @@ allocate(Config) ->
     DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
     Expected = [
         <<(I - 1):25/integer-unsigned-little, DevAddrPrefix:7/integer>>
-     || I <- lists:seq(1, 8)
+        || I <- lists:seq(1, 8)
     ],
     ?assertEqual(lists:sort(Expected ++ Expected), lists:sort(DevAddrs)),
     ok.
@@ -165,10 +165,9 @@ route_packet(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     ok.

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -375,7 +375,12 @@ bad_fcnt_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -377,10 +377,9 @@ bad_fcnt_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -162,7 +162,12 @@ device_worker_late_packet_double_charge_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     {ok, #{<<"id">> := UplinkUUID}} = test_utils:wait_for_console_event_sub(
@@ -846,7 +851,12 @@ replay_uplink_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     timer:sleep(2000 + 100),
@@ -903,7 +913,12 @@ replay_uplink_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     ok.

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -164,10 +164,9 @@ device_worker_late_packet_double_charge_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     {ok, #{<<"id">> := UplinkUUID}} = test_utils:wait_for_console_event_sub(
@@ -853,10 +852,9 @@ replay_uplink_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     timer:sleep(2000 + 100),
@@ -915,10 +913,9 @@ replay_uplink_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     ok.

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -187,7 +187,12 @@ disovery_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     [_, Payload2 | _] = DiscoveryData1#discovery_start_pb.packets,
@@ -257,7 +262,12 @@ disovery_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Restart process one more to make sure device worker behaves correctly
@@ -345,7 +355,12 @@ disovery_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     ok.
@@ -431,7 +446,12 @@ fail_to_connect_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     ok.

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -189,10 +189,9 @@ disovery_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     [_, Payload2 | _] = DiscoveryData1#discovery_start_pb.packets,
@@ -264,10 +263,9 @@ disovery_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Restart process one more to make sure device worker behaves correctly
@@ -357,10 +355,9 @@ disovery_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     ok.
@@ -448,10 +445,9 @@ fail_to_connect_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     ok.

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -328,10 +328,9 @@ test_downlink_message_for_channel(Config, DownlinkPayload, DownlinkMessage, Expe
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -326,7 +326,12 @@ test_downlink_message_for_channel(Config, DownlinkPayload, DownlinkMessage, Expe
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -337,10 +337,9 @@ lw_join_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from console downlink
@@ -511,10 +510,9 @@ lw_join_test(Config) ->
             }
         ],
         <<"dc">> => #{
-                      <<"dc_balance">> => fun erlang:is_integer/1,
-                      <<"nonce">> => fun erlang:is_integer/1
-                     }
-
+            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"nonce">> => fun erlang:is_integer/1
+        }
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -335,7 +335,12 @@ lw_join_test(Config) ->
                 <<"lat">> => '_',
                 <<"long">> => '_'
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from console downlink
@@ -504,7 +509,12 @@ lw_join_test(Config) ->
                 <<"lat">> => '_',
                 <<"long">> => '_'
             }
-        ]
+        ],
+        <<"dc">> => #{
+                      <<"dc_balance">> => fun erlang:is_integer/1,
+                      <<"nonce">> => fun erlang:is_integer/1
+                     }
+
     }),
 
     %% Waiting for report channel status from HTTP channel

--- a/test/router_xor_filter_SUITE.erl
+++ b/test/router_xor_filter_SUITE.erl
@@ -394,7 +394,7 @@ migrate_filter_test(Config) ->
                 {Three, fun xxhash:hash64/1},
                 router_xor_filter_worker:deveui_appeui(Device)
             )
-         || Device <- AllDevices
+            || Device <- AllDevices
         ]),
         "No devices in filter Three"
     ),
@@ -405,7 +405,7 @@ migrate_filter_test(Config) ->
                 {Four, fun xxhash:hash64/1},
                 router_xor_filter_worker:deveui_appeui(Device)
             )
-         || Device <- AllDevices
+            || Device <- AllDevices
         ]),
         "No devices in filter Four"
     ),
@@ -853,7 +853,7 @@ remove_devices_filter_after_restart_test(Config) ->
             {Filter, fun xxhash:hash64/1},
             router_xor_filter_worker:deveui_appeui(Device)
         )
-     || Filter <- Filters1, Device <- Removed
+        || Filter <- Filters1, Device <- Removed
     ],
     ?assertEqual(
         true,


### PR DESCRIPTION
This PR adds DC balance and nonce (integers, both) to channel messages.  The added fields look like this:

```
   "dc" : {
      "dc_balance": 42,
      "nonce": 123456
   }
```