### PR TITLE
Ignore TxDr Logic

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1153,7 +1153,7 @@ maybe_send_queue_update(Device, #state{queue_updates = {ForwardPid, LabelID, _}}
     ForwardPid !
         {?MODULE, queue_update, LabelID, router_device:id(Device), [
             downlink_to_map(D)
-            || D <- router_device:queue(Device)
+         || D <- router_device:queue(Device)
         ]},
     ok.
 
@@ -1167,8 +1167,9 @@ maybe_send_queue_update(Device, #state{queue_updates = {ForwardPid, LabelID, _}}
     Blockchain :: blockchain:blockchain(),
     OfferCache :: map()
 ) ->
-    {ok, router_device:device(), binary(), #join_accept_args{},
-        {Balance :: non_neg_integer(), Nonce :: non_neg_integer()}}
+    {ok, router_device:device(), binary(), #join_accept_args{}, {
+        Balance :: non_neg_integer(), Nonce :: non_neg_integer()
+    }}
     | {error, any()}.
 validate_join(
     #packet_pb{
@@ -1904,7 +1905,7 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
                             Region,
                             {NewTxPowerIdx, NewDr, [Channels]},
                             []
-                        );
+                        )
                 end;
             _ ->
                 []
@@ -1962,9 +1963,19 @@ frame_to_packet_payload(Frame, Device) ->
     FOpts = lorawan_mac_commands:encode_fopts(Frame#frame.fopts),
     FOptsLen = erlang:byte_size(FOpts),
     PktHdr =
-        <<(Frame#frame.mtype):3, 0:3, 0:2, (Frame#frame.devaddr)/binary, (Frame#frame.adr):1, 0:1,
-            (Frame#frame.ack):1, (Frame#frame.fpending):1, FOptsLen:4,
-            (Frame#frame.fcnt):16/integer-unsigned-little, FOpts:FOptsLen/binary>>,
+        <<
+            (Frame#frame.mtype):3,
+            0:3,
+            0:2,
+            (Frame#frame.devaddr)/binary,
+            (Frame#frame.adr):1,
+            0:1,
+            (Frame#frame.ack):1,
+            (Frame#frame.fpending):1,
+            FOptsLen:4,
+            (Frame#frame.fcnt):16/integer-unsigned-little,
+            FOpts:FOptsLen/binary
+        >>,
     NwkSKey = router_device:nwk_s_key(Device),
     PktBody =
         case Frame#frame.data of
@@ -1997,8 +2008,10 @@ frame_to_packet_payload(Frame, Device) ->
         cmac,
         aes_128_cbc,
         NwkSKey,
-        <<(router_utils:b0(1, Frame#frame.devaddr, Frame#frame.fcnt, byte_size(Msg)))/binary,
-            Msg/binary>>,
+        <<
+            (router_utils:b0(1, Frame#frame.devaddr, Frame#frame.fcnt, byte_size(Msg)))/binary,
+            Msg/binary
+        >>,
         4
     ),
     <<Msg/binary, MIC/binary>>.

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1855,11 +1855,26 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
             %% Some regions allow the channel list to be sent in the join response as well,
             %% so we may need to do that there as well
             {true, false, _} ->
-                lorawan_mac_region:set_channels(
-                    Region,
-                    {0, erlang:list_to_binary(DataRate), [Channels]},
-                    []
-                );
+                case Region of
+                    'US915' ->
+                        lorawan_mac_region:set_channels(
+                            Region,
+                            {0, <<"NoChange">>, [Channels]},
+                            []
+                        );
+                    'AU915' ->
+                        lorawan_mac_region:set_channels(
+                            Region,
+                            {0, <<"NoChange">>, [Channels]},
+                            []
+                        );
+                    _ ->
+                        lorawan_mac_region:set_channels(
+                            Region,
+                            {0, erlang:list_to_binary(DataRate), [Channels]},
+                            []
+                        )
+                end;
             {false, _, {NewDataRateIdx, NewTxPowerIdx}} ->
                 %% begin-needs-refactor
                 %%
@@ -1869,12 +1884,28 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
                 %% rate in the form of "SFdd?BWddd?" so that's what
                 %% we'll give it.
                 NewDr = lorawan_mac_region:dr_to_datar(Region, NewDataRateIdx),
+                NewTxPowerIdx = 0,
                 %% end-needs-refactor
-                lorawan_mac_region:set_channels(
-                    Region,
-                    {NewTxPowerIdx, NewDr, [Channels]},
-                    []
-                );
+                case Region of
+                    'US915' ->
+                        lorawan_mac_region:set_channels(
+                            Region,
+                            {NewTxPowerIdx, <<"NoChange">>, [Channels]},
+                            []
+                        );
+                    'AU915' ->
+                        lorawan_mac_region:set_channels(
+                            Region,
+                            {NewTxPowerIdx, <<"NoChange">>, [Channels]},
+                            []
+                        );
+                    _ ->
+                        lorawan_mac_region:set_channels(
+                            Region,
+                            {NewTxPowerIdx, NewDr, [Channels]},
+                            []
+                        );
+                end;
             _ ->
                 []
         end,

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1885,28 +1885,12 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
                 %% rate in the form of "SFdd?BWddd?" so that's what
                 %% we'll give it.
                 NewDr = lorawan_mac_region:dr_to_datar(Region, NewDataRateIdx),
-                NewTxPowerIdx = 0,
                 %% end-needs-refactor
-                case Region of
-                    'US915' ->
-                        lorawan_mac_region:set_channels(
-                            Region,
-                            {NewTxPowerIdx, <<"NoChange">>, [Channels]},
-                            []
-                        );
-                    'AU915' ->
-                        lorawan_mac_region:set_channels(
-                            Region,
-                            {NewTxPowerIdx, <<"NoChange">>, [Channels]},
-                            []
-                        );
-                    _ ->
-                        lorawan_mac_region:set_channels(
-                            Region,
-                            {NewTxPowerIdx, NewDr, [Channels]},
-                            []
-                        )
-                end;
+                lorawan_mac_region:set_channels(
+                    Region,
+                    {NewTxPowerIdx, NewDr, [Channels]},
+                    []
+                );
             _ ->
                 []
         end,

--- a/src/lora/lorawan_mac_region.erl
+++ b/src/lora/lorawan_mac_region.erl
@@ -176,8 +176,10 @@ rx1_or_rx2_window(Region, Delay, Offset, RxQ) ->
     case TopLevelRegion of
         'EU868' ->
             if
-                % In Europe the RX Windows uses different frequencies, TX power rules and Duty cycle rules.
-                % If the signal is poor then prefer window 2 where TX power is higher.  See - https://github.com/helium/router/issues/423
+                % In Europe the RX Windows uses different frequencies,
+                % TX power rules and Duty cycle rules.  If the signal is
+                % poor then prefer window 2 where TX power is higher.
+                % See - https://github.com/helium/router/issues/423
                 RxQ#rxq.rssi < -80 -> rx2_window(Region, Delay, RxQ);
                 true -> rx1_window(Region, Delay, Offset, RxQ)
             end;
@@ -784,8 +786,8 @@ uplink_power_table_('EU868') ->
 %% Bobcat team was testing and noticed downlink `rf_power' was too high for CN470.
 %%
 %% longAP team was testing and also noticed `rf_power' was too high for EU868.
-%% Followup from disk91:
-%% https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf (page 22)
+%% Followup from disk91: (page 22)
+%% https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf
 %% MwToDb = fun(Mw) -> round(10 * math:log10(Mw)) end.
 %%
 %% NOTE: We may want to reduce to default tx_power

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -281,17 +281,17 @@ device_worker_late_packet_double_charge_test(Config) ->
                     <<"channel_mask">> => 0,
                     <<"channel_mask_control">> => 7,
                     <<"command">> => <<"link_adr_req">>,
-                    <<"data_rate">> => 2,
+                    <<"data_rate">> => 15,
                     <<"number_of_transmissions">> => 0,
-                    <<"tx_power">> => 0
+                    <<"tx_power">> => 15
                 },
                 #{
                     <<"channel_mask">> => 65280,
                     <<"channel_mask_control">> => 0,
                     <<"command">> => <<"link_adr_req">>,
-                    <<"data_rate">> => 2,
+                    <<"data_rate">> => 15,
                     <<"number_of_transmissions">> => 0,
-                    <<"tx_power">> => 0
+                    <<"tx_power">> => 15
                 }
             ]
         }


### PR DESCRIPTION
Solution to address #633.  The spec allows Tx=0xF and Dr=0xF to indicated that DR and/or TX should be ignored and the end-device should continue to use it's current DR and TX settings.