### PR TITLE
Rename "dc_balance" to "balance"

### DIFF
--- a/src/device/router_device_channels_worker.erl
+++ b/src/device/router_device_channels_worker.erl
@@ -665,7 +665,7 @@ send_data_to_channel(CachedData0, Device, EventMgrRef, Blockchain, BalanceNonce)
         devaddr => lorawan_utils:binary_to_hex(DevAddr),
         hotspots => lists:map(FormatHotspot, CachedData1),
         dc => #{
-            <<"dc_balance">> => Balance,
+            <<"balance">> => Balance,
             <<"nonce">> => Nonce
         }
     },

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -295,7 +295,7 @@ dupes_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -1626,7 +1626,7 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -1821,7 +1821,7 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -2015,7 +2015,7 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -2215,7 +2215,7 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -2370,7 +2370,7 @@ adr_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_channel_console_SUITE.erl
+++ b/test/router_channel_console_SUITE.erl
@@ -222,7 +222,7 @@ inactive_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -378,7 +378,7 @@ inactive_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_channel_http_SUITE.erl
+++ b/test/router_channel_http_SUITE.erl
@@ -127,7 +127,7 @@ http_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -265,7 +265,7 @@ http_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -466,7 +466,7 @@ http_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -865,7 +865,7 @@ http_decoded_payload_test(Config) ->
         <<"devaddr">> => '_',
         <<"hotspots">> => fun erlang:is_list/1,
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_channel_iot_hub_SUITE.erl
+++ b/test/router_channel_iot_hub_SUITE.erl
@@ -170,7 +170,7 @@ iot_hub_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -317,7 +317,7 @@ iot_hub_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_channel_mqtt_SUITE.erl
+++ b/test/router_channel_mqtt_SUITE.erl
@@ -141,7 +141,7 @@ mqtt_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -297,7 +297,7 @@ mqtt_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -522,7 +522,7 @@ mqtt_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -691,7 +691,7 @@ mqtt_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -862,7 +862,7 @@ mqtt_update_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_channel_no_channel_SUITE.erl
+++ b/test/router_channel_no_channel_SUITE.erl
@@ -220,7 +220,7 @@ no_channel_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_console_dc_tracker_SUITE.erl
+++ b/test/router_console_dc_tracker_SUITE.erl
@@ -145,7 +145,7 @@ dc_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -145,7 +145,7 @@ data_test_1(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -288,7 +288,7 @@ data_test_2(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -430,7 +430,7 @@ data_test_3(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_decoder_SUITE.erl
+++ b/test/router_decoder_SUITE.erl
@@ -135,7 +135,7 @@ decode_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -254,7 +254,7 @@ timeout_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -354,7 +354,7 @@ too_many_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_device_channels_worker_SUITE.erl
+++ b/test/router_device_channels_worker_SUITE.erl
@@ -665,7 +665,7 @@ late_packet_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -165,7 +165,7 @@ route_packet(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_device_routing_SUITE.erl
+++ b/test/router_device_routing_SUITE.erl
@@ -377,7 +377,7 @@ bad_fcnt_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -164,7 +164,7 @@ device_worker_late_packet_double_charge_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -852,7 +852,7 @@ replay_uplink_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -913,7 +913,7 @@ replay_uplink_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_discovery_SUITE.erl
+++ b/test/router_discovery_SUITE.erl
@@ -189,7 +189,7 @@ disovery_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -263,7 +263,7 @@ disovery_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -355,7 +355,7 @@ disovery_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -445,7 +445,7 @@ fail_to_connect_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -328,7 +328,7 @@ test_downlink_message_for_channel(Config, DownlinkPayload, DownlinkMessage, Expe
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -337,7 +337,7 @@ lw_join_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),
@@ -510,7 +510,7 @@ lw_join_test(Config) ->
             }
         ],
         <<"dc">> => #{
-            <<"dc_balance">> => fun erlang:is_integer/1,
+            <<"balance">> => fun erlang:is_integer/1,
             <<"nonce">> => fun erlang:is_integer/1
         }
     }),


### PR DESCRIPTION
This commit renames the "dc_balance" field found in channel data to
"balance".