### PR TITLE
Improve CTs

### DIFF
--- a/src/device/router_device_multibuy.erl
+++ b/src/device/router_device_multibuy.erl
@@ -372,6 +372,45 @@ scheduled_cleanup_test() ->
     _ = catch ets:delete(?ETS_MAX),
     ok.
 
+scheduled_cleanup_test() ->
+    _ = catch ets:delete(?ETS),
+    _ = catch ets:delete(?ETS_MAX),
+
+    ok = ?MODULE:init(),
+
+    %% Setup Max packet for device
+    DeviceID = router_utils:uuid_v4(),
+    Max = 5,
+    ?assertEqual(ok, ?MODULE:max(DeviceID, Max)),
+
+    Packets = 100,
+    lists:foreach(
+        fun(_) ->
+            %% Populate table with a bunch of different packets and max values
+            erlang:spawn(
+                fun() ->
+                    PHash = crypto:strong_rand_bytes(32),
+                    ok = ?MODULE:max(DeviceID, Max),
+                    ok = ?MODULE:maybe_buy(DeviceID, PHash)
+                end
+            )
+        end,
+        lists:seq(1, Packets)
+    ),
+
+    %% Wait 100ms and then run a cleanup for 10ms
+    timer:sleep(100),
+    Time = erlang:system_time(millisecond) - 10,
+    ?assertEqual(Packets, erlang:length(select_expired(Time))),
+    ok = scheduled_cleanup(10),
+    timer:sleep(100),
+    % %% It should remove every values except the device max
+    ?assertEqual(Max, ?MODULE:max(DeviceID)),
+    ?assertEqual(0, erlang:length(select_expired(Time))),
+    ?assertEqual(0, ets:info(?ETS, size)),
+    ?assertEqual(1, ets:info(?ETS_MAX, size)),
+    ok.
+
 maybe_buy_test_rcv_loop(Acc) ->
     receive
         {maybe_buy_test, X, Time, Result} ->

--- a/src/device/router_device_multibuy.erl
+++ b/src/device/router_device_multibuy.erl
@@ -373,9 +373,6 @@ scheduled_cleanup_test() ->
     ok.
 
 scheduled_cleanup_test() ->
-    _ = catch ets:delete(?ETS),
-    _ = catch ets:delete(?ETS_MAX),
-
     ok = ?MODULE:init(),
 
     %% Setup Max packet for device
@@ -409,6 +406,9 @@ scheduled_cleanup_test() ->
     ?assertEqual(0, erlang:length(select_expired(Time))),
     ?assertEqual(0, ets:info(?ETS, size)),
     ?assertEqual(1, ets:info(?ETS_MAX, size)),
+
+    _ = catch ets:delete(?ETS),
+    _ = catch ets:delete(?ETS_MAX),
     ok.
 
 maybe_buy_test_rcv_loop(Acc) ->

--- a/test/router_device_worker_utils.erl
+++ b/test/router_device_worker_utils.erl
@@ -1,0 +1,75 @@
+-module(router_device_worker_utils).
+
+-export([
+    channels_worker/1,
+    dev_nonce/1,
+    event_manager/1,
+    fcnt/1,
+    device/1,
+    offer_cache/1,
+    refresh_channels/1
+]).
+
+-spec channels_worker(router_device:id()) -> pid().
+channels_worker(DeviceID) ->
+    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
+    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
+        _OUI, ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADREngine,
+        _IsActive, _Discovery} = sys:get_state(
+        WorkerPid
+    ),
+    ChannelsWorkerPid.
+
+-spec dev_nonce(router_device:id()) -> non_neg_integer().
+dev_nonce(DeviceID) ->
+    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
+    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
+        _OUI, _ChannelsWorkerPid, LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
+        _IsActive, _Discovery} = sys:get_state(
+        WorkerPid
+    ),
+    LastDevNonce.
+
+-spec event_manager(router_device:id()) -> pid().
+event_manager(DeviceID) ->
+    ChannelWorkerPid = ?MODULE:channels_worker(DeviceID),
+    {state, _Chain, EventManagerPid, _DeviceWorkerPid, _Device, _Channels, _ChannelsBackoffs,
+        _DataCache} = sys:get_state(ChannelWorkerPid),
+    EventManagerPid.
+
+-spec fcnt(router_device:id()) -> non_neg_integer().
+fcnt(DeviceID) ->
+    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
+    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, FCnt,
+        _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
+        _IsActive, _Discovery} = sys:get_state(
+        WorkerPid
+    ),
+    FCnt.
+
+-spec device(router_device:id()) -> router_device:device().
+device(DeviceID) ->
+    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
+    {state, _Chain, _DB, _CF, _FrameTimeout, Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
+        _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
+        _IsActive, _Discovery} = sys:get_state(
+        WorkerPid
+    ),
+    Device.
+
+-spec offer_cache(router_device:id()) -> map().
+offer_cache(DeviceID) ->
+    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
+    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
+        _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, OfferCache, _ADRCache,
+        _IsActive, _Discovery} = sys:get_state(
+        WorkerPid
+    ),
+    OfferCache.
+
+-spec refresh_channels(router_device:id()) -> ok.
+refresh_channels(DeviceID) ->
+    Pid = ?MODULE:channels_worker(DeviceID),
+    Pid ! refresh_channels,
+    timer:sleep(250),
+    ok.

--- a/test/router_test_console.erl
+++ b/test/router_test_console.erl
@@ -1,0 +1,46 @@
+-module(router_test_console).
+
+-export([
+    init/0,
+    lookup_devices/0,
+    lookup_device/1,
+    insert_device/2
+]).
+
+-define(ETS, router_test_console_ets).
+-define(DEVICE_KEY(DeviceID), {device, DeviceID}).
+
+init() ->
+    _ = ets:new(?ETS, [public, set, named_table]),
+    ElliOpts = [
+        {callback, router_test_console_callback},
+        {callback_args, #{
+            forward => self()
+        }},
+        {port, 3000}
+    ],
+    {ok, Pid} = elli:start_link(ElliOpts),
+    application:ensure_all_started(gun),
+    lager:info("started @ ~p", [Pid]),
+    Pid.
+
+-spec lookup_devices() -> [router_device:device()].
+lookup_devices() ->
+    ets:select(?ETS, [
+        {{{device, '$1'}, '$2'}, [], ['$2']}
+    ]).
+
+-spec lookup_device(DeviceID :: router_device:id()) ->
+    {ok, router_device:device(), binary()} | {error, not_found}.
+lookup_device(DeviceID) ->
+    case ets:lookup(?ETS, ?DEVICE_KEY(DeviceID)) of
+        [{?DEVICE_KEY(DeviceID), {Device, AppKey}}] ->
+            {ok, Device, AppKey};
+        [] ->
+            {error, not_found}
+    end.
+
+-spec insert_device(Device :: router_device:device(), AppKey :: binary()) -> ok.
+insert_device(Device, AppKey) ->
+    true = ets:insert(?ETS, {?DEVICE_KEY(router_device:id(Device)), {Device, AppKey}}),
+    ok.

--- a/test/router_test_console.hrl
+++ b/test/router_test_console.hrl
@@ -1,0 +1,19 @@
+-define(CONSOLE_IP_PORT, <<"127.0.0.1:3000">>).
+-define(CONSOLE_URL, <<"http://", ?CONSOLE_IP_PORT/binary>>).
+-define(CONSOLE_WS_URL, <<"ws://", ?CONSOLE_IP_PORT/binary, "/websocket">>).
+
+-define(CONSOLE_HTTP_CHANNEL_DOWNLINK_TOKEN, <<"downlink_token_123">>).
+-define(CONSOLE_HTTP_CHANNEL_ID, <<"12345">>).
+-define(CONSOLE_HTTP_CHANNEL_NAME, <<"fake_http">>).
+-define(CONSOLE_HTTP_CHANNEL, #{
+    <<"type">> => <<"http">>,
+    <<"credentials">> => #{
+        <<"headers">> => #{},
+        <<"url_params">> => #{},
+        <<"endpoint">> => <<?CONSOLE_URL/binary, "/channel">>,
+        <<"method">> => <<"POST">>
+    },
+    <<"downlink_token">> => ?CONSOLE_HTTP_CHANNEL_DOWNLINK_TOKEN,
+    <<"id">> => ?CONSOLE_HTTP_CHANNEL_ID,
+    <<"name">> => ?CONSOLE_HTTP_CHANNEL_NAME
+}).

--- a/test/router_test_console_callback.erl
+++ b/test/router_test_console_callback.erl
@@ -3,8 +3,6 @@
 -behaviour(elli_handler).
 -behaviour(elli_websocket_handler).
 
--include("console_test.hrl").
-
 -export([
     init/2,
     handle/2,
@@ -97,7 +95,7 @@ handle(
         <<"api">>,
         <<"router">>,
         <<"devices">>,
-        _DID,
+        _DeviceID,
         <<"event">>
     ],
     Req,
@@ -111,7 +109,7 @@ handle(
     ct:print("Console Event: ~p (~p)~n~n~p", [Cat, SubCat, Data]),
     Pid ! {console_event, Cat, SubCat, Data},
     {200, [], <<>>};
-%% INTEGRATION: Post
+%% HTTP INTEGRATION: Post
 handle('POST', [<<"channel">>], Req, Args) ->
     Pid = maps:get(forward, Args),
     Body = elli_request:body(Req),

--- a/test/router_test_console_callback.erl
+++ b/test/router_test_console_callback.erl
@@ -1,0 +1,199 @@
+-module(router_test_console_callback).
+
+-behaviour(elli_handler).
+-behaviour(elli_websocket_handler).
+
+-include("console_test.hrl").
+
+-export([
+    init/2,
+    handle/2,
+    handle_event/3
+]).
+
+-export([
+    websocket_init/2,
+    websocket_handle/3,
+    websocket_info/3,
+    websocket_handle_event/3
+]).
+
+init(Req, Args) ->
+    case elli_request:get_header(<<"Upgrade">>, Req) of
+        <<"websocket">> ->
+            init_ws(elli_request:path(Req), Req, Args);
+        _ ->
+            ignore
+    end.
+
+handle(Req, _Args) ->
+    Method =
+        case elli_request:get_header(<<"Upgrade">>, Req) of
+            <<"websocket">> ->
+                websocket;
+            _ ->
+                elli_request:method(Req)
+        end,
+    handle(Method, elli_request:path(Req), Req, _Args).
+
+%% CONSOLE: Get token
+handle('POST', [<<"api">>, <<"router">>, <<"sessions">>], _Req, _Args) ->
+    Body = #{<<"jwt">> => <<"console_callback_token">>},
+    {201, [], jsx:encode(Body)};
+%% CONSOLE: Get unknown device
+handle('GET', [<<"api">>, <<"router">>, <<"devices">>, <<"unknown">>], _Req, _Args) ->
+    Body = lists:map(
+        fun({Device, Appkey}) ->
+            Meta = router_device:metadata(Device),
+            #{
+                <<"id">> => router_device:id(Device),
+                <<"name">> => router_device:name(Device),
+                <<"app_key">> => lorawan_utils:binary_to_hex(Appkey),
+                <<"app_eui">> => lorawan_utils:binary_to_hex(router_device:app_eui(Device)),
+                <<"dev_eui">> => lorawan_utils:binary_to_hex(router_device:dev_eui(Device)),
+                %% TODO OPTIONS FOR ALL THIS
+                <<"channels">> => [],
+                <<"labels">> => maps:get(labels, Meta),
+                <<"organization_id">> => maps:get(organization_id, Meta),
+                <<"active">> => true,
+                <<"multi_buy">> => 1,
+                <<"adr_allowed">> => false,
+                <<"cf_list_enabled">> => false,
+                <<"rx_delay">> => 1
+            }
+        end,
+        router_test_console:lookup_devices()
+    ),
+    {200, [], jsx:encode(Body)};
+%% CONSOLE:  Get Device
+handle('GET', [<<"api">>, <<"router">>, <<"devices">>, DeviceID], _Req, _Args) ->
+    case router_test_console:lookup_device(DeviceID) of
+        {error, not_found} ->
+            {404, [], <<"Not Found">>};
+        {ok, Device, Appkey} ->
+            Meta = router_device:metadata(Device),
+            Body = #{
+                <<"id">> => router_device:id(Device),
+                <<"name">> => router_device:name(Device),
+                <<"app_key">> => lorawan_utils:binary_to_hex(Appkey),
+                <<"app_eui">> => lorawan_utils:binary_to_hex(router_device:app_eui(Device)),
+                <<"dev_eui">> => lorawan_utils:binary_to_hex(router_device:dev_eui(Device)),
+                %% TODO OPTIONS FOR ALL THIS
+                <<"channels">> => maps:get(channels, Meta),
+                <<"labels">> => maps:get(labels, Meta),
+                <<"organization_id">> => maps:get(organization_id, Meta),
+                <<"active">> => router_device:is_active(Device),
+                <<"multi_buy">> => maps:get(multi_buy, Meta),
+                <<"adr_allowed">> => maps:get(adr_allowed, Meta),
+                <<"cf_list_enabled">> => maps:get(cf_list_enabled, Meta),
+                <<"rx_delay">> => maps:get(rx_delay, Meta)
+            },
+            {200, [], jsx:encode(Body)}
+    end;
+%% CONSOLE: Post event
+handle(
+    'POST',
+    [
+        <<"api">>,
+        <<"router">>,
+        <<"devices">>,
+        _DID,
+        <<"event">>
+    ],
+    Req,
+    Args
+) ->
+    Pid = maps:get(forward, Args),
+    Body = elli_request:body(Req),
+    Data = jsx:decode(Body, [return_maps]),
+    Cat = maps:get(<<"category">>, Data, <<"unknown">>),
+    SubCat = maps:get(<<"sub_category">>, Data, <<"unknown">>),
+    ct:print("Console Event: ~p (~p)~n~n~p", [Cat, SubCat, Data]),
+    Pid ! {console_event, Cat, SubCat, Data},
+    {200, [], <<>>};
+%% INTEGRATION: Post
+handle('POST', [<<"channel">>], Req, Args) ->
+    Pid = maps:get(forward, Args),
+    Body = elli_request:body(Req),
+    try jsx:decode(Body, [return_maps]) of
+        JSON ->
+            Pid ! {channel_data, JSON},
+            Reply = base64:encode(<<"reply">>),
+            case maps:find(<<"payload">>, JSON) of
+                {ok, Reply} ->
+                    {200, [],
+                        jsx:encode(#{
+                            payload_raw => base64:encode(<<"ack">>),
+                            port => 1,
+                            confirmed => true
+                        })};
+                _ ->
+                    {200, [], <<"success">>}
+            end
+    catch
+        _:_ ->
+            {400, [], <<"bad_body">>}
+    end;
+handle('websocket', [<<"websocket">>], Req, Args) ->
+    %% Upgrade to a websocket connection.
+    elli_websocket:upgrade(Req, [
+        {handler, ?MODULE},
+        {handler_opts, Args}
+    ]),
+    %% websocket is closed:
+    %% See RFC-6455 (https://tools.ietf.org/html/rfc6455) for a list of
+    %% valid WS status codes than can be used on a close frame.
+    %% Note that the second element is the reason and is abitrary but should be meaningful
+    %% in regards to your server and sub-protocol.
+    {close, <<"1000">>};
+handle(_Method, _Path, _Req, _Args) ->
+    ct:pal("got unknown ~p req on ~p args=~p", [_Method, _Path, _Args]),
+    {404, [], <<"Not Found">>}.
+
+handle_event(_Event, _Data, _Args) ->
+    ok.
+
+websocket_init(Req, Opts) ->
+    lager:info("websocket_init ~p", [Req]),
+    lager:info("websocket_init ~p", [Opts]),
+    maps:get(forward, Opts) ! {websocket_init, self()},
+    {ok, [], Opts}.
+
+websocket_handle(_Req, {text, Msg}, State) ->
+    {ok, Map} = router_console_ws_handler:decode_msg(Msg),
+    handle_message(Map, State);
+websocket_handle(_Req, _Frame, State) ->
+    lager:info("websocket_handle ~p", [_Frame]),
+    {ok, State}.
+
+websocket_info(_Req, _Msg, State) ->
+    lager:info("websocket_info ~p", [_Msg]),
+    {ok, State}.
+
+websocket_handle_event(_Event, _Args, _State) ->
+    lager:info("websocket_handle_event ~p", [_Event]),
+    ok.
+
+handle_message(#{ref := Ref, topic := <<"phoenix">>, event := <<"heartbeat">>}, State) ->
+    Data = router_console_ws_handler:encode_msg(Ref, <<"phoenix">>, <<"phx_reply">>, #{
+        <<"status">> => <<"ok">>
+    }),
+    {reply, {text, Data}, State};
+handle_message(#{ref := Ref, topic := Topic, event := <<"phx_join">>}, State) ->
+    Data = router_console_ws_handler:encode_msg(
+        Ref,
+        Topic,
+        <<"phx_reply">>,
+        #{<<"status">> => <<"ok">>},
+        Ref
+    ),
+    {reply, {text, Data}, State};
+handle_message(Map, #{forward := Pid} = State) ->
+    lager:info("got unhandle message ~p ~p", [Map, lager:pr(State, ?MODULE)]),
+    Pid ! {websocket_msg, Map},
+    {ok, State}.
+
+init_ws([<<"websocket">>], _Req, _Args) ->
+    {ok, handover};
+init_ws(_, _, _) ->
+    ignore.

--- a/test/router_test_device.erl
+++ b/test/router_test_device.erl
@@ -1,0 +1,386 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Router Test Device ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(router_test_device).
+
+-behavior(gen_server).
+
+-include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
+-include("router_test_console.hrl").
+-include("lorawan_vars.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+-export([
+    start/1,
+    join/2,
+    uplink/2,
+    hotspot_pubkey_bin/1,
+    device/1,
+    joined/1,
+    fcnt/1,
+    downlinks/1
+]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+-export([
+    init/1,
+    handle_continue/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(SERVER, ?MODULE).
+-define(POST_INIT, post_init).
+-define(APP_EUI, <<0, 0, 0, 0, 0, 0, 0, 1>>).
+
+-record(state, {
+    hotspot_privkey :: libp2p_crypto:privkey(),
+    hotspot_sig_fun :: libp2p_crypto:sig_fun(),
+    hotspot_pubkey :: libp2p_crypto:pubkey(),
+    hotspot_pubkey_bin :: libp2p_crypto:pubkey_bin(),
+    hotspot_name :: string(),
+    device :: router_device:device(),
+    device_app_key = crypto:strong_rand_bytes(16) :: binary(),
+    device_dev_nonce = crypto:strong_rand_bytes(2) :: binary(),
+    device_joined = false :: boolean(),
+    device_fcnt = 0 :: non_neg_integer(),
+    device_downlinks = queue:new() :: queue:queue()
+}).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start(Args) ->
+    gen_server:start(?SERVER, Args, []).
+
+-spec join(Pid :: pid(), Opts :: map()) ->
+    {ok, blockchain_helium_packet_v1:packet()} | {error, any()}.
+join(Pid, Opts) ->
+    gen_server:call(Pid, {join, Opts}).
+
+-spec uplink(Pid :: pid(), Opts :: map()) ->
+    {ok, blockchain_helium_packet_v1:packet()} | {error, any()}.
+uplink(Pid, Opts) ->
+    gen_server:call(Pid, {uplink, Opts}).
+
+-spec hotspot_pubkey_bin(Pid :: pid()) -> libp2p_crypto:pubkey_bin().
+hotspot_pubkey_bin(Pid) ->
+    gen_server:call(Pid, hotspot_pubkey_bin).
+
+-spec device(Pid :: pid()) -> router_device:device().
+device(Pid) ->
+    gen_server:call(Pid, device).
+
+-spec joined(Pid :: pid()) -> boolean().
+joined(Pid) ->
+    gen_server:call(Pid, joined).
+
+-spec fcnt(Pid :: pid()) -> non_neg_integer().
+fcnt(Pid) ->
+    gen_server:call(Pid, fcnt).
+
+-spec downlinks(Pid :: pid()) -> blockchain_helium_packet_v1:packet() | undefined.
+downlinks(Pid) ->
+    gen_server:call(Pid, downlinks).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+init(Args) ->
+    #{secret := PrivKey, public := PubKey} = maps:get(
+        hotspot_keys,
+        Args,
+        libp2p_crypto:generate_keys(ecc_compact)
+    ),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    DeviceID = maps:get(id, Args, router_utils:uuid_v4()),
+    OrgID = maps:get(organization_id, Args, router_utils:uuid_v4()),
+    DefaultMeta = #{
+        channels => [?CONSOLE_HTTP_CHANNEL],
+        labels => #{},
+        organization_id => OrgID,
+        multi_buy => 1,
+        adr_allowed => false,
+        cf_list_enabled => true,
+        rx_delay => 0
+    },
+    DeviceUpdates = [
+        {name, <<"DEVICE_", DeviceID/binary>>},
+        {dev_eui, crypto:strong_rand_bytes(8)},
+        {app_eui, ?APP_EUI},
+        {is_active, maps:get(is_active, Args, true)},
+        {metadata, maps:merge(DefaultMeta, maps:get(metadata, Args, #{}))}
+    ],
+    Device = router_device:update(DeviceUpdates, router_device:new(DeviceID)),
+    ok = router_console_dc_tracker:refill(OrgID, 1, 100),
+    {ok,
+        #state{
+            hotspot_privkey = PrivKey,
+            hotspot_sig_fun = libp2p_crypto:mk_sig_fun(PrivKey),
+            hotspot_pubkey = PubKey,
+            hotspot_pubkey_bin = PubKeyBin,
+            hotspot_name = blockchain_utils:addr2name(PubKeyBin),
+            device = Device
+        },
+        {continue, ?POST_INIT}}.
+
+handle_continue(
+    ?POST_INIT,
+    #state{hotspot_name = Name, device = Device, device_app_key = AppKey} = State
+) ->
+    ok = router_test_console:insert_device(Device, AppKey),
+    lager:info("post init for hotspot ~p device ~p", [Name, router_device:id(Device)]),
+    {noreply, State};
+handle_continue(_Msg, State) ->
+    lager:warning("rcvd unknown continue msg: ~p", [_Msg]),
+    {noreply, State}.
+
+handle_call({join, Opts}, _From, State) ->
+    SCPacket = build_join_req(Opts, State),
+    Result = router_device_routing:handle_packet(
+        SCPacket,
+        erlang:system_time(millisecond),
+        self()
+    ),
+    case Result of
+        ok ->
+            lager:info("join ~p", [Result]),
+            {reply, {ok, SCPacket}, State};
+        _ ->
+            lager:info("failed to join ~p", [Result]),
+            {reply, Result, State}
+    end;
+handle_call({uplink, Opts}, _From, State0) ->
+    {SCPacket, FCnt1} = build_uplink(Opts, State0),
+    State1 = State0#state{device_fcnt = FCnt1},
+    Result = router_device_routing:handle_packet(
+        SCPacket,
+        erlang:system_time(millisecond),
+        self()
+    ),
+    case Result of
+        ok ->
+            lager:info("uplink ~p", [Result]),
+            {reply, {ok, SCPacket}, State1};
+        _ ->
+            lager:info("failed to uplink ~p", [Result]),
+            {reply, Result, State1}
+    end;
+handle_call(device, _From, #state{device = Device} = State) ->
+    {reply, Device, State};
+handle_call(hotspot_pubkey_bin, _From, #state{hotspot_pubkey_bin = PubKeyBin} = State) ->
+    {reply, PubKeyBin, State};
+handle_call(joined, _From, #state{device_joined = Joined} = State) ->
+    {reply, Joined, State};
+handle_call(fcnt, _From, #state{device_fcnt = FCnt} = State) ->
+    {reply, FCnt, State};
+handle_call(downlinks, _From, #state{device_downlinks = Downlinks0} = State) ->
+    case queue:out_r(Downlinks0) of
+        {{value, Downlink}, Downlinks1} ->
+            {reply, Downlink, State#state{device_downlinks = Downlinks1}};
+        {empty, _} ->
+            {reply, undefined, State}
+    end;
+handle_call(_Msg, _From, State) ->
+    lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    lager:warning("rcvd unknown cast msg: ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info(
+    {send_response, #blockchain_state_channel_response_v1_pb{
+        downlink = #packet_pb{payload = Payload}
+    }},
+    #state{
+        device = Device0,
+        device_app_key = AppKey,
+        device_dev_nonce = DevNonce,
+        device_joined = false
+    } = State
+) ->
+    %% TODO: we could do more join check here
+    {ok, NwkSKey, AppSKey, DevAddr, _DLSettings, _RxDelay, _CFList} = decrypt_join_accept(
+        Payload,
+        DevNonce,
+        AppKey
+    ),
+    Device1 = router_device:devaddr(DevAddr, Device0),
+    Device2 = router_device:keys([{NwkSKey, AppSKey}], Device1),
+    lager:info("joined", []),
+    {noreply, State#state{device = Device2, device_joined = true}};
+handle_info(
+    {send_response, #blockchain_state_channel_response_v1_pb{
+        downlink = Packet
+    }},
+    #state{device_joined = true, device_downlinks = Downlinks} = State
+) ->
+    lager:info("got downlink ~p", [lager:pr(Packet, blockchain_helium_packet_v1)]),
+    {noreply, State#state{device_downlinks = queue:in_r(Packet, Downlinks)}};
+handle_info(_Msg, State) ->
+    lager:warning("rcvd unknown info msg: ~p, ~p", [_Msg, State]),
+    {noreply, State}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, #state{}) ->
+    lager:warning("terminate ~p", [_Reason]),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+build_join_req(Opts, #state{
+    hotspot_pubkey_bin = PubKeyBin,
+    device = Device,
+    device_app_key = AppKey,
+    device_dev_nonce = DevNonce
+}) ->
+    lager:info("joining with DevNonce=~p", [DevNonce]),
+    AppEUI = router_device:app_eui(Device),
+    DevEUI = router_device:dev_eui(Device),
+    HeliumPacket = blockchain_helium_packet_v1:new(
+        lorawan,
+        join_payload(AppEUI, DevEUI, AppKey, DevNonce),
+        erlang:system_time(millisecond),
+        maps:get(rssi, Opts, 0.0),
+        maps:get(freq, Opts, 923.3),
+        maps:get(dr, Opts, "SF8BW125"),
+        maps:get(snr, Opts, 0.0),
+        {eui, bin_to_int(DevEUI), bin_to_int(AppEUI)}
+    ),
+    lager:info("joining with HeliumPacket=~p", [lager:pr(HeliumPacket, blockchain_helium_packet_v1)]),
+    SCPacket = blockchain_state_channel_packet_v1:new(
+        HeliumPacket,
+        PubKeyBin,
+        maps:get(region, Opts, 'US915'),
+        maps:get(hold_time, Opts, rand:uniform(2000))
+    ),
+    lager:info("joining with SCPacket=~p", [lager:pr(SCPacket, blockchain_state_channel_packet_v1)]),
+    SCPacket.
+
+-spec join_payload(
+    AppEUI0 :: binary(),
+    DevEUI0 :: binary(),
+    AppKey :: binary(),
+    DevNonce :: binary()
+) -> binary().
+join_payload(AppEUI0, DevEUI0, AppKey, DevNonce) ->
+    MType = ?JOIN_REQ,
+    MHDRRFU = 0,
+    Major = 0,
+    AppEUI1 = lorawan_utils:reverse(AppEUI0),
+    DevEUI1 = lorawan_utils:reverse(DevEUI0),
+    Payload0 =
+        <<MType:3, MHDRRFU:3, Major:2, AppEUI1:8/binary, DevEUI1:8/binary, DevNonce:2/binary>>,
+    MIC = crypto:macN(cmac, aes_128_cbc, AppKey, Payload0, 4),
+    <<Payload0/binary, MIC:4/binary>>.
+
+-spec decrypt_join_accept(binary(), binary(), binary()) -> any().
+decrypt_join_accept(
+    <<MType:3, _MHDRRFU:3, _Major:2, EncPayload/binary>>,
+    DevNonce,
+    AppKey
+) when MType == ?JOIN_ACCEPT ->
+    Payload = crypto:crypto_one_time(aes_128_ecb, AppKey, EncPayload, true),
+    {AppNonce, NetID, DevAddr, DLSettings, RxDelay, MIC, CFList} =
+        case Payload of
+            <<AN:3/binary, NID:3/binary, DA:4/binary, DL:8/integer-unsigned, RxD:8/integer-unsigned,
+                M:4/binary>> ->
+                CFL = <<>>,
+                {AN, NID, DA, DL, RxD, M, CFL};
+            <<AN:3/binary, NID:3/binary, DA:4/binary, DL:8/integer-unsigned, RxD:8/integer-unsigned,
+                CFL:16/binary, M:4/binary>> ->
+                {AN, NID, DA, DL, RxD, M, CFL}
+        end,
+    Msg = binary:part(Payload, {0, erlang:byte_size(Payload) - 4}),
+    MIC = crypto:macN(cmac, aes_128_cbc, AppKey, <<MType:3, _MHDRRFU:3, _Major:2, Msg/binary>>, 4),
+    NwkSKey = crypto:crypto_one_time(
+        aes_128_ecb,
+        AppKey,
+        lorawan_utils:padded(16, <<16#01, AppNonce/binary, NetID/binary, DevNonce/binary>>),
+        true
+    ),
+    AppSKey = crypto:crypto_one_time(
+        aes_128_ecb,
+        AppKey,
+        lorawan_utils:padded(16, <<16#02, AppNonce/binary, NetID/binary, DevNonce/binary>>),
+        true
+    ),
+    {ok, NwkSKey, AppSKey, DevAddr, DLSettings, RxDelay, CFList}.
+
+build_uplink(Opts, #state{
+    hotspot_pubkey_bin = PubKeyBin,
+    device = Device,
+    device_fcnt = FCnt
+}) ->
+    lager:info("uplink with FCnt=~p", [FCnt]),
+    DevAddr = router_device:devaddr(Device),
+    <<DevNum:32/integer-unsigned-little>> = DevAddr,
+    AppSKey = router_device:app_s_key(Device),
+    NwkSKey = router_device:nwk_s_key(Device),
+    HeliumPacket = blockchain_helium_packet_v1:new(
+        lorawan,
+        uplink_payload(FCnt, NwkSKey, AppSKey, DevAddr, Opts),
+        erlang:system_time(millisecond),
+        maps:get(rssi, Opts, 0),
+        maps:get(freq, Opts, 923.3),
+        maps:get(dr, Opts, "SF8BW125"),
+        maps:get(snr, Opts, 0.0),
+        {devaddr, DevNum}
+    ),
+    lager:info("uplink with HeliumPacket=~p", [lager:pr(HeliumPacket, blockchain_helium_packet_v1)]),
+    SCPacket = blockchain_state_channel_packet_v1:new(
+        HeliumPacket,
+        PubKeyBin,
+        maps:get(region, Opts, 'US915'),
+        maps:get(hold_time, Opts, rand:uniform(2000))
+    ),
+    lager:info("uplink with SCPacket=~p", [lager:pr(SCPacket, blockchain_state_channel_packet_v1)]),
+    {SCPacket, FCnt + 1}.
+
+uplink_payload(FCnt, NwkSKey, AppSKey, DevAddr, Opts) ->
+    MType = maps:get(mtype, Opts, ?UNCONFIRMED_UP),
+    OptionsBoolToBit = fun(Key) ->
+        case maps:get(Key, Opts, false) of
+            true -> 1;
+            false -> 0
+        end
+    end,
+    MHDRRFU = 0,
+    Major = 0,
+    ADR = OptionsBoolToBit(wants_adr),
+    ADRACKReq = OptionsBoolToBit(wants_adr_ack),
+    ACK = OptionsBoolToBit(wants_ack),
+    RFU = 0,
+    FOptsBin = lorawan_mac_commands:encode_fupopts(maps:get(fopts, Opts, [])),
+    FOptsLen = erlang:byte_size(FOptsBin),
+    <<Port:8/integer, Body/binary>> = maps:get(body, Opts, <<1:8>>),
+    Data = lorawan_utils:reverse(
+        lorawan_utils:cipher(Body, AppSKey, MType band 1, DevAddr, FCnt)
+    ),
+    FCntSize = maps:get(fcnt_size, Opts, 16),
+    Payload0 =
+        <<MType:3, MHDRRFU:3, Major:2, DevAddr:4/binary, ADR:1, ADRACKReq:1, ACK:1, RFU:1,
+            FOptsLen:4, FCnt:FCntSize/little-unsigned-integer, FOptsBin:FOptsLen/binary,
+            Port:8/integer, Data/binary>>,
+    B0 = router_utils:b0(MType band 1, DevAddr, FCnt, erlang:byte_size(Payload0)),
+    MIC = crypto:macN(cmac, aes_128_cbc, NwkSKey, <<B0/binary, Payload0/binary>>, 4),
+    <<Payload0/binary, MIC:4/binary>>.
+
+-spec bin_to_int(binary()) -> integer().
+bin_to_int(<<EUI:64/integer-unsigned-big>>) ->
+    EUI.

--- a/test/router_test_device.erl
+++ b/test/router_test_device.erl
@@ -122,7 +122,8 @@ init(Args) ->
         {metadata, maps:merge(DefaultMeta, maps:get(metadata, Args, #{}))}
     ],
     Device = router_device:update(DeviceUpdates, router_device:new(DeviceID)),
-    ok = router_console_dc_tracker:refill(OrgID, 1, 100),
+    OrgBalance = maps:get(organization_balance, Args, 100),
+    ok = router_console_dc_tracker:refill(OrgID, 1, OrgBalance),
     {ok,
         #state{
             hotspot_privkey = PrivKey,

--- a/test/router_test_device_SUITE.erl
+++ b/test/router_test_device_SUITE.erl
@@ -127,11 +127,12 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => Freq,
-                <<"channel">> => 105,
+                <<"channel">> => 0,
                 <<"lat">> => fun check_lat/1,
                 <<"long">> => fun check_long/1
             }
-        ]
+        ],
+        <<"dc">> => fun erlang:is_map/1
     }),
 
     test_utils:wait_for_console_event_sub(<<"uplink_unconfirmed">>, #{
@@ -160,7 +161,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => Freq,
-                <<"channel">> => 105,
+                <<"channel">> => 0,
                 <<"lat">> => fun check_lat/1,
                 <<"long">> => fun check_long/1
             },

--- a/test/router_test_device_SUITE.erl
+++ b/test/router_test_device_SUITE.erl
@@ -1,0 +1,190 @@
+-module(router_test_device_SUITE).
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    data_test_1/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("router_test_console.hrl").
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [
+        data_test_1
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    test_utils:init_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(TestCase, Config) ->
+    test_utils:end_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+data_test_1(Config) ->
+    [{PrivKey, PubKey} | _] = proplists:get_value(hotspots, Config),
+    {ok, TestDevicePid} = router_test_device:start(#{
+        hotspot_keys => #{secret => PrivKey, public => PubKey}
+    }),
+
+    ok = test_utils:join_device(TestDevicePid),
+
+    TestDevice = router_test_device:device(TestDevicePid),
+    DeviceID = router_device:id(TestDevice),
+    PubKeyBin = router_test_device:hotspot_pubkey_bin(TestDevicePid),
+    HotspotName = blockchain_utils:addr2name(PubKeyBin),
+
+    %% Check that device is in cache now
+    {ok, DB, CF} = router_db:get_devices(),
+    {ok, Device} = router_device:get_by_id(DB, CF, DeviceID),
+
+    %% Send UNCONFIRMED_UP frame packet
+    DataRate = <<"SF8BW125">>,
+    Freq = 923.2999877929688,
+    RSSI = -97.0,
+    SNR = -12.100000381469727,
+    Port = 2,
+    Body = <<"body">>,
+    Payload = <<Port:8/integer, Body/binary>>,
+    HoldTime = rand:uniform(2000),
+    {ok, SCPacket} = router_test_device:uplink(TestDevicePid, #{
+        freq => Freq,
+        dr => erlang:binary_to_list(DataRate),
+        rssi => RSSI,
+        snr => SNR,
+        body => Payload,
+        hold_time => HoldTime
+    }),
+
+    ReportedAtCheck = fun(ReportedAt) ->
+        Now = erlang:system_time(millisecond),
+        Now - ReportedAt < 250 andalso Now - ReportedAt > 0
+    end,
+
+    %% Waiting for data from HTTP channel
+    test_utils:wait_channel_data(#{
+        <<"type">> => <<"uplink">>,
+        <<"replay">> => false,
+        <<"uuid">> => fun erlang:is_binary/1,
+        <<"id">> => DeviceID,
+        <<"downlink_url">> =>
+            <<?CONSOLE_URL/binary, "/api/v1/down/", ?CONSOLE_HTTP_CHANNEL_ID/binary, "/",
+                ?CONSOLE_HTTP_CHANNEL_DOWNLINK_TOKEN/binary, "/", DeviceID/binary>>,
+        <<"name">> => router_device:name(TestDevice),
+        <<"dev_eui">> => lorawan_utils:binary_to_hex(router_device:dev_eui(TestDevice)),
+        <<"app_eui">> => lorawan_utils:binary_to_hex(router_device:app_eui(TestDevice)),
+        <<"metadata">> => #{
+            <<"labels">> => #{},
+            <<"organization_id">> => maps:get(organization_id, router_device:metadata(TestDevice)),
+            <<"multi_buy">> => 1,
+            <<"adr_allowed">> => false,
+            <<"cf_list_enabled">> => false,
+            <<"rx_delay">> => 1,
+            <<"rx_delay_actual">> => 1,
+            <<"rx_delay_state">> => <<"rx_delay_established">>
+        },
+        <<"fcnt">> => 0,
+        <<"reported_at">> => ReportedAtCheck,
+        <<"payload">> => base64:encode(Body),
+        <<"payload_size">> => erlang:byte_size(Body),
+        <<"raw_packet">> => base64:encode(
+            blockchain_helium_packet_v1:payload(blockchain_state_channel_packet_v1:packet(SCPacket))
+        ),
+        <<"port">> => Port,
+        <<"devaddr">> => lorawan_utils:binary_to_hex(router_device:devaddr(Device)),
+        <<"hotspots">> => [
+            #{
+                <<"id">> => erlang:list_to_binary(libp2p_crypto:bin_to_b58(PubKeyBin)),
+                <<"name">> => erlang:list_to_binary(HotspotName),
+                <<"reported_at">> => ReportedAtCheck,
+                <<"hold_time">> => HoldTime,
+                <<"status">> => <<"success">>,
+                <<"rssi">> => RSSI,
+                <<"snr">> => SNR,
+                <<"spreading">> => DataRate,
+                <<"frequency">> => Freq,
+                <<"channel">> => 105,
+                <<"lat">> => fun check_lat/1,
+                <<"long">> => fun check_long/1
+            }
+        ]
+    }),
+
+    test_utils:wait_for_console_event_sub(<<"uplink_unconfirmed">>, #{
+        <<"id">> => fun erlang:is_binary/1,
+        <<"category">> => <<"uplink">>,
+        <<"sub_category">> => <<"uplink_unconfirmed">>,
+        <<"description">> => fun erlang:is_binary/1,
+        <<"reported_at">> => ReportedAtCheck,
+        <<"device_id">> => DeviceID,
+        <<"data">> => #{
+            <<"dc">> => fun erlang:is_map/1,
+            <<"fcnt">> => 0,
+            <<"payload_size">> => erlang:byte_size(Body),
+            <<"payload">> => base64:encode(Body),
+            <<"raw_packet">> => base64:encode(
+                blockchain_helium_packet_v1:payload(
+                    blockchain_state_channel_packet_v1:packet(SCPacket)
+                )
+            ),
+            <<"port">> => Port,
+            <<"devaddr">> => lorawan_utils:binary_to_hex(router_device:devaddr(Device)),
+            <<"hotspot">> => #{
+                <<"id">> => erlang:list_to_binary(libp2p_crypto:bin_to_b58(PubKeyBin)),
+                <<"name">> => erlang:list_to_binary(HotspotName),
+                <<"rssi">> => RSSI,
+                <<"snr">> => SNR,
+                <<"spreading">> => DataRate,
+                <<"frequency">> => Freq,
+                <<"channel">> => 105,
+                <<"lat">> => fun check_lat/1,
+                <<"long">> => fun check_long/1
+            },
+            <<"mac">> => [],
+            <<"hold_time">> => HoldTime
+        }
+    }),
+
+    ok.
+
+%% ------------------------------------------------------------------
+%% Helper functions
+%% ------------------------------------------------------------------
+
+%% this is due to floating points...
+-spec check_lat(float()) -> boolean().
+check_lat(Lat) when Lat < 37.01 andalso Lat > 36.99 ->
+    true;
+check_lat(_) ->
+    false.
+
+%% this is due to floating points...
+-spec check_long(float()) -> boolean().
+check_long(Long) when Long < -120.0 andalso Long > -122.0 ->
+    true;
+check_long(_) ->
+    false.

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -3,34 +3,16 @@
 -export([
     init_per_testcase/2,
     end_per_testcase/2,
-    add_oui/1,
-    start_swarm/3,
-    get_device_channels_worker/1,
-    get_channel_worker_event_manager/1,
-    get_device_last_seen_fcnt/1,
-    get_last_dev_nonce/1,
-    get_device_worker_device/1,
-    get_device_worker_offer_cache/1,
-    get_device_queue/1,
-    force_refresh_channels/1,
+
+    join_device/1, join_device/2,
+
     ignore_messages/0,
+
     wait_for_console_event/2,
     wait_for_console_event_sub/2,
-    wait_for_join_resp/3,
     wait_channel_data/1,
-    wait_state_channel_message/1,
-    wait_state_channel_message/2,
-    wait_state_channel_message/3,
-    wait_state_channel_message/8,
     wait_organizations_burned/1,
-    wait_state_channel_packet/1,
-    join_payload/2,
-    join_packet/3, join_packet/4,
-    join_device/1, join_device/2,
-    frame_payload/6,
-    frame_packet/5, frame_packet/6,
-    deframe_packet/2,
-    deframe_join_packet/3,
+
     tmp_dir/0, tmp_dir/1,
     wait_until/1, wait_until/3,
     wait_until_no_messages/1,
@@ -42,22 +24,15 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--include("router_device_worker.hrl").
 -include("lorawan_vars.hrl").
 -include("console_test.hrl").
 
 -define(BASE_TMP_DIR, "./_build/test/tmp").
 -define(BASE_TMP_DIR_TEMPLATE, "XXXXXXXXXX").
--define(APPEUI, <<0, 0, 0, 2, 0, 0, 0, 1>>).
--define(DEVEUI, <<0, 0, 0, 0, 0, 0, 0, 1>>).
 
+-spec init_per_testcase(atom(), list()) -> list().
 init_per_testcase(TestCase, Config) ->
-    meck:new(router_device_devaddr, [passthrough]),
-    meck:expect(router_device_devaddr, allocate, fun(_, _) ->
-        DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
-        {ok, <<33554431:25/integer-unsigned-little, DevAddrPrefix:7/integer>>}
-    end),
-
+    %% Setup application env for Router / Chain / Lager
     BaseDir = erlang:atom_to_list(TestCase),
     ok = application:set_env(blockchain, base_dir, BaseDir ++ "/router_swarm_data"),
     ok = application:set_env(router, testing, true),
@@ -122,26 +97,22 @@ init_per_testcase(TestCase, Config) ->
         _ ->
             ok
     end,
-    Tab = ets:new(TestCase, [public, set]),
-    AppKey = crypto:strong_rand_bytes(16),
-    ElliOpts = [
-        {callback, console_callback},
-        {callback_args, #{
-            forward => self(),
-            ets => Tab,
-            app_key => AppKey,
-            app_eui => ?APPEUI,
-            dev_eui => ?DEVEUI
-        }},
-        {port, 3010}
-    ],
-    {ok, Pid} = elli:start_link(ElliOpts),
-    application:ensure_all_started(gun),
 
-    _ = router_test_console:init(),
+    %% FIX ME: Mocking router_device_devaddr as we do not have a proper OUI setup  maybe fixed by add OUI?
+    % meck:new(router_device_devaddr, [passthrough]),
+    % meck:expect(router_device_devaddr, allocate, fun(_, _) ->
+    %     DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+    %     {ok, <<33554431:25/integer-unsigned-little, DevAddrPrefix:7/integer>>}
+    % end),
 
+    %% Start testing Console
+    TestConsolePid = router_test_console:init(self()),
+    ct:pal("testing Console started @ ~p", [TestConsolePid]),
+
+    %% Start Router
     {ok, _} = application:ensure_all_started(router),
 
+    % Grab Router's keys
     SwarmKey = filename:join([
         application:get_env(blockchain, base_dir, "data"),
         "blockchain",
@@ -151,130 +122,50 @@ init_per_testcase(TestCase, Config) ->
     {ok, RouterKeys} = libp2p_crypto:load_keys(SwarmKey),
     #{public := RouterPubKey, secret := RouterPrivKey} = RouterKeys,
 
-    HotspotDir = BaseDir ++ "/hotspot",
-    filelib:ensure_dir(HotspotDir),
-    {HotspotSwarm, HotspotKeys} = ?MODULE:start_swarm(HotspotDir, TestCase, 0),
-    #{public := HotspotPubKey, secret := HotspotPrivKey} = HotspotKeys,
-
-    RandomHotspots = lists:map(
+    % Generate some keys to act as hotspots
+    RandomHotspotsKey = lists:map(
         fun(_) ->
             #{secret := PrivKey, public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
             {PrivKey, PubKey}
         end,
-        lists:seq(1, 5)
+        lists:seq(1, 10)
     ),
 
+    %% Insert Keys into init chain each keys will receive a locationa as well as some DC
+    %% FIX ME: maybe Router should not get inserted as a gateway as well
     {ok, _GenesisMembers, ConsensusMembers, _Keys} = blockchain_test_utils:init_chain(
         5000,
-        [{RouterPrivKey, RouterPubKey}, {HotspotPrivKey, HotspotPubKey}] ++ RandomHotspots
+        [{RouterPrivKey, RouterPubKey}] ++ RandomHotspotsKey
     ),
 
-    ok = router_console_dc_tracker:refill(?CONSOLE_ORG_ID, 1, 100),
+    %% Create OUI Routing and advance chain 1 block
+    OUI = 1,
+    ok = add_oui(OUI, ConsensusMembers),
 
     [
-        {app_key, AppKey},
-        {ets, Tab},
-        {elli, Pid},
         {base_dir, BaseDir},
-        {swarm, HotspotSwarm},
-        {keys, HotspotKeys},
-        {hotspots, RandomHotspots},
-        {consensus_member, ConsensusMembers}
+        {hotspots, RandomHotspotsKey},
+        {consensus_member, ConsensusMembers},
+        {test_console, TestConsolePid},
+        {oui, OUI}
         | Config
     ].
 
+-spec end_per_testcase(atom(), list()) -> ok.
 end_per_testcase(_TestCase, Config) ->
-    catch libp2p_swarm:stop(proplists:get_value(swarm, Config)),
-    Pid = proplists:get_value(elli, Config),
-    {ok, Acceptors} = elli:get_acceptors(Pid),
-    ok = elli:stop(Pid),
-    timer:sleep(500),
-    [catch erlang:exit(A, kill) || A <- Acceptors],
+    Pid = proplists:get_value(test_console, Config),
+    ok = router_test_console:stop(Pid),
     ok = application:stop(router),
     ok = application:stop(lager),
     e2qc:teardown(router_console_api_get_devices_by_deveui_appeui),
     e2qc:teardown(router_console_api_get_org),
     application:stop(e2qc),
     ok = application:stop(throttle),
-    Tab = proplists:get_value(ets, Config),
-    ets:delete(Tab),
-    meck:unload(router_device_devaddr),
+    % meck:unload(router_device_devaddr),
     ok.
-
-start_swarm(BaseDir, Name, Port) ->
-    Keys = libp2p_crypto:generate_keys(ecc_compact),
-    #{secret := PrivKey, public := PubKey} = Keys,
-    Key = {PubKey, libp2p_crypto:mk_sig_fun(PrivKey), libp2p_crypto:mk_ecdh_fun(PrivKey)},
-    SwarmOpts = [
-        {base_dir, BaseDir ++ "/" ++ erlang:atom_to_list(Name) ++ "_data"},
-        {key, Key},
-        {libp2p_group_gossip, [{seed_nodes, []}]},
-        {libp2p_nat, [{enabled, false}]},
-        {libp2p_proxy, [{limit, 1}]}
-    ],
-    {ok, Swarm} = libp2p_swarm:start(Name, SwarmOpts),
-    libp2p_swarm:listen(Swarm, "/ip4/0.0.0.0/tcp/" ++ erlang:integer_to_list(Port)),
-    ct:pal("created swarm ~p @ ~p p2p address=~p", [Name, Swarm, libp2p_swarm:p2p_address(Swarm)]),
-    {Swarm, Keys}.
-
-add_oui(Config) ->
-    {ok, PubKey, SigFun, _} = blockchain_swarm:keys(),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
-
-    Chain = blockchain_worker:blockchain(),
-    Ledger = blockchain:ledger(Chain),
-    ConsensusMembers = proplists:get_value(consensus_member, Config),
-
-    %% Create and submit OUI txn with an empty filter
-    OUI = 1,
-    {Filter, _} = xor16:to_bin(xor16:new([0], fun xxhash:hash64/1)),
-    OUITxn = blockchain_txn_oui_v1:new(OUI, PubKeyBin, [PubKeyBin], Filter, 8),
-    OUITxnFee = blockchain_txn_oui_v1:calculate_fee(OUITxn, Chain),
-    OUITxnStakingFee = blockchain_txn_oui_v1:calculate_staking_fee(OUITxn, Chain),
-    OUITxn0 = blockchain_txn_oui_v1:fee(OUITxn, OUITxnFee),
-    OUITxn1 = blockchain_txn_oui_v1:staking_fee(OUITxn0, OUITxnStakingFee),
-
-    SignedOUITxn = blockchain_txn_oui_v1:sign(OUITxn1, SigFun),
-
-    ?assertEqual({error, not_found}, blockchain_ledger_v1:find_routing(OUI, Ledger)),
-
-    {ok, Block0} = blockchain_test_utils:create_block(ConsensusMembers, [SignedOUITxn]),
-    _ = blockchain_test_utils:add_block(Block0, Chain, self(), blockchain_swarm:tid()),
-
-    ok = test_utils:wait_until(fun() -> {ok, 2} == blockchain:height(Chain) end),
-    [{oui, OUI} | Config].
 
 join_device(Config) ->
     join_device(Config, #{}).
-
-join_device(Config, JoinOpts) ->
-    AppKey = proplists:get_value(app_key, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    RouterSwarm = blockchain_swarm:swarm(),
-    [Address | _] = libp2p_swarm:listen_addrs(RouterSwarm),
-    {ok, Stream} = libp2p_swarm:dial_framed_stream(
-        Swarm,
-        Address,
-        router_handler_test:version(),
-        router_handler_test,
-        [self()]
-    ),
-    PubKeyBin = libp2p_swarm:pubkey_bin(Swarm),
-    {ok, HotspotName} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(PubKeyBin)),
-
-    %% Send join packet
-    DevNonce = crypto:strong_rand_bytes(2),
-    SCPacket = ?MODULE:join_packet(
-        PubKeyBin,
-        AppKey,
-        DevNonce,
-        maps:put(dont_encode, true, JoinOpts)
-    ),
-    Stream !
-        {send,
-            blockchain_state_channel_v1_pb:encode_msg(#blockchain_state_channel_message_v1_pb{
-                msg = {packet, SCPacket}
-            })},
 
 join_device(TestDevicePid, JoinOpts) ->
     {ok, SCPacket} = router_test_device:join(TestDevicePid, JoinOpts),
@@ -348,67 +239,6 @@ join_device(TestDevicePid, JoinOpts) ->
             }
         }
     }),
-    ok.
-
-get_device_channels_worker(DeviceID) ->
-    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
-    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
-        _OUI, ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADREngine,
-        _IsActive, _Discovery} = sys:get_state(
-        WorkerPid
-    ),
-    ChannelsWorkerPid.
-
-get_last_dev_nonce(DeviceID) ->
-    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
-    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
-        _OUI, _ChannelsWorkerPid, LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
-        _IsActive, _Discovery} = sys:get_state(
-        WorkerPid
-    ),
-    LastDevNonce.
-
-get_channel_worker_event_manager(DeviceID) ->
-    ChannelWorkerPid = get_device_channels_worker(DeviceID),
-    {state, _Chain, EventManagerPid, _DeviceWorkerPid, _Device, _Channels, _ChannelsBackoffs,
-        _DataCache} = sys:get_state(ChannelWorkerPid),
-    EventManagerPid.
-
-get_device_last_seen_fcnt(DeviceID) ->
-    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
-    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, FCnt,
-        _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
-        _IsActive, _Discovery} = sys:get_state(
-        WorkerPid
-    ),
-    FCnt.
-
-get_device_worker_device(DeviceID) ->
-    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
-    {state, _Chain, _DB, _CF, _FrameTimeout, Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
-        _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, _OfferCache, _ADRCache,
-        _IsActive, _Discovery} = sys:get_state(
-        WorkerPid
-    ),
-    Device.
-
-get_device_worker_offer_cache(DeviceID) ->
-    {ok, WorkerPid} = router_devices_sup:lookup_device_worker(DeviceID),
-    {state, _Chain, _DB, _CF, _FrameTimeout, _Device, _QueueUpdates, _DownlinkHandlkedAt, _FCnt,
-        _OUI, _ChannelsWorkerPid, _LastDevNonce, _JoinChache, _FrameCache, OfferCache, _ADRCache,
-        _IsActive, _Discovery} = sys:get_state(
-        WorkerPid
-    ),
-    OfferCache.
-
-get_device_queue(DeviceID) ->
-    Device = ?MODULE:get_device_worker_device(DeviceID),
-    router_device:queue(Device).
-
-force_refresh_channels(DeviceID) ->
-    Pid = get_device_channels_worker(DeviceID),
-    Pid ! refresh_channels,
-    timer:sleep(250),
     ok.
 
 ignore_messages() ->
@@ -534,29 +364,6 @@ wait_for_console_event_sub(SubCategory, Expected) ->
             ct:fail("wait_for_console_event_sub ~p failed", [SubCategory])
     end.
 
-wait_for_join_resp(PubKeyBin, AppKey, DevNonce) ->
-    receive
-        {client_data, PubKeyBin, Data} ->
-            try
-                blockchain_state_channel_v1_pb:decode_msg(
-                    Data,
-                    blockchain_state_channel_message_v1_pb
-                )
-            of
-                #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
-                    #blockchain_state_channel_response_v1_pb{accepted = true, downlink = Packet} =
-                        Resp,
-                    ct:pal("packet ~p", [Packet]),
-                    Frame = deframe_join_packet(Packet, DevNonce, AppKey),
-                    ct:pal("Join response ~p", [Frame]),
-                    Frame
-            catch
-                _:_ ->
-                    ct:fail("invalid join response")
-            end
-    after 1250 -> ct:fail("missing_join for")
-    end.
-
 wait_channel_data(Expected) ->
     Got =
         receive
@@ -574,176 +381,6 @@ wait_channel_data(Expected) ->
         _Class:_Reason:_Stacktrace ->
             ct:pal("wait_channel_data stacktrace ~n~p", [{_Reason, _Stacktrace}]),
             ct:fail("wait_channel_data failed caught ~p", [_Reason])
-    end.
-
-wait_state_channel_message(Timeout) ->
-    wait_state_channel_message(Timeout, undefined).
-
-wait_state_channel_message(Timeout, PubKeyBin) ->
-    try
-        receive
-            {client_data, PubKeyBin, Data} ->
-                try
-                    blockchain_state_channel_v1_pb:decode_msg(
-                        Data,
-                        blockchain_state_channel_message_v1_pb
-                    )
-                of
-                    #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
-                        #blockchain_state_channel_response_v1_pb{accepted = true} = Resp,
-                        ok;
-                    _Else ->
-                        ct:fail("wait_state_channel_message wrong message ~p ", [_Else])
-                catch
-                    _E:_R ->
-                        ct:fail("wait_state_channel_message failed to decode ~p ~p", [
-                            Data,
-                            {_E, _R}
-                        ])
-                end
-        after Timeout -> ct:fail("wait_state_channel_message timeout")
-        end
-    catch
-        _Class:_Reason:_Stacktrace ->
-            ct:pal("wait_state_channel_message stacktrace ~n~p", [{_Reason, _Stacktrace}]),
-            ct:fail("wait_state_channel_message failed")
-    end.
-
-wait_state_channel_message(Timeout, PubKeyBin, AppSKey) ->
-    try
-        receive
-            {client_data, PubKeyBin, Data} ->
-                try
-                    blockchain_state_channel_v1_pb:decode_msg(
-                        Data,
-                        blockchain_state_channel_message_v1_pb
-                    )
-                of
-                    #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
-                        case Resp of
-                            #blockchain_state_channel_response_v1_pb{
-                                accepted = true,
-                                downlink = undefined
-                            } ->
-                                wait_state_channel_message(Timeout, PubKeyBin, AppSKey);
-                            #blockchain_state_channel_response_v1_pb{
-                                accepted = true,
-                                downlink = Packet
-                            } ->
-                                {ok, deframe_packet(Packet, AppSKey)}
-                        end;
-                    _Else ->
-                        ct:fail("wait_state_channel_message with frame wrong message ~p ", [_Else])
-                catch
-                    _E:_R ->
-                        ct:fail("wait_state_channel_message with frame failed to decode ~p ~p", [
-                            Data,
-                            {_E, _R}
-                        ])
-                end
-        after Timeout -> ct:fail("wait_state_channel_message with frame timeout")
-        end
-    catch
-        _Class:_Reason:_Stacktrace ->
-            ct:pal("wait_state_channel_message with frame stacktrace ~n~p", [{_Reason, _Stacktrace}]),
-            ct:fail("wait_state_channel_message with frame failed")
-    end.
-
-wait_state_channel_message(Msg, Device, FrameData, Type, FPending, Ack, Fport, FCnt) ->
-    try
-        receive
-            {client_data, undefined, Data} ->
-                try
-                    blockchain_state_channel_v1_pb:decode_msg(
-                        Data,
-                        blockchain_state_channel_message_v1_pb
-                    )
-                of
-                    #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
-                        case Resp of
-                            #blockchain_state_channel_response_v1_pb{
-                                accepted = true,
-                                downlink = undefined
-                            } ->
-                                wait_state_channel_message(
-                                    Msg,
-                                    Device,
-                                    FrameData,
-                                    Type,
-                                    FPending,
-                                    Ack,
-                                    Fport,
-                                    FCnt
-                                );
-                            #blockchain_state_channel_response_v1_pb{
-                                accepted = true,
-                                downlink = Packet
-                            } ->
-                                ct:pal("wait_state_channel_message packet ~p", [Packet]),
-                                Frame = deframe_packet(Packet, router_device:app_s_key(Device)),
-                                ct:pal("~p", [lager:pr(Frame, ?MODULE)]),
-                                ?assertEqual(FrameData, Frame#frame.data),
-                                %% we queued an unconfirmed packet
-                                ?assertEqual(Type, Frame#frame.mtype),
-                                ?assertEqual(FPending, Frame#frame.fpending),
-                                ?assertEqual(Ack, Frame#frame.ack),
-                                ?assertEqual(Fport, Frame#frame.fport),
-                                ?assertEqual(FCnt, Frame#frame.fcnt),
-                                {ok, Frame}
-                        end;
-                    _Else ->
-                        ct:fail("wait_state_channel_message wrong message ~p for ~p", [_Else, Msg])
-                catch
-                    _E:_R ->
-                        ct:fail("wait_state_channel_message failed to decode ~p ~p for ~p", [
-                            Data,
-                            {_E, _R},
-                            Msg
-                        ])
-                end
-        after 1250 -> ct:fail("wait_state_channel_message timeout for ~p", [Msg])
-        end
-    catch
-        _Class:_Reason:_Stacktrace ->
-            ct:pal("wait_state_channel_message stacktrace ~n~p", [{_Reason, _Stacktrace}]),
-            ct:fail("wait_state_channel_message failed")
-    end.
-
-wait_state_channel_packet(Timeout) ->
-    try
-        receive
-            {client_data, _, Data} ->
-                try
-                    blockchain_state_channel_v1_pb:decode_msg(
-                        Data,
-                        blockchain_state_channel_message_v1_pb
-                    )
-                of
-                    #blockchain_state_channel_message_v1_pb{msg = {response, Resp}} ->
-                        case Resp of
-                            #blockchain_state_channel_response_v1_pb{
-                                accepted = true,
-                                downlink = Packet
-                            } ->
-                                {ok, Packet};
-                            _ ->
-                                {error, Resp}
-                        end;
-                    _Else ->
-                        ct:fail("wait_state_channel_packet with frame wrong message ~p ", [_Else])
-                catch
-                    _E:_R ->
-                        ct:fail("wait_state_channel_packet with frame failed to decode ~p ~p", [
-                            Data,
-                            {_E, _R}
-                        ])
-                end
-        after Timeout -> ct:fail("wait_state_channel_packet with frame timeout")
-        end
-    catch
-        _Class:_Reason:_Stacktrace ->
-            ct:pal("wait_state_channel_packet with frame stacktrace ~n~p", [{_Reason, _Stacktrace}]),
-            ct:fail("wait_state_channel_packet with frame failed")
     end.
 
 wait_organizations_burned(Expected) ->
@@ -764,111 +401,6 @@ wait_organizations_burned(Expected) ->
             ct:pal("wait_organizations_burned stacktrace ~n~p", [{_Reason, _Stacktrace}]),
             ct:fail("wait_organizations_burned failed")
     end.
-
-join_packet(PubKeyBin, AppKey, DevNonce) ->
-    join_packet(PubKeyBin, AppKey, DevNonce, #{}).
-
-join_packet(PubKeyBin, AppKey, DevNonce, Options) ->
-    %% THIS IS WRONG
-    RoutingInfo = {devaddr, 1},
-    RSSI = maps:get(rssi, Options, 0),
-    HeliumPacket = blockchain_helium_packet_v1:new(
-        lorawan,
-        join_payload(AppKey, DevNonce),
-        1000,
-        RSSI,
-        923.3,
-        <<"SF8BW125">>,
-        0.0,
-        RoutingInfo
-    ),
-    Region = maps:get(region, Options, 'US915'),
-    Packet = #blockchain_state_channel_packet_v1_pb{
-        packet = HeliumPacket,
-        hotspot = PubKeyBin,
-        region = Region
-    },
-    case maps:get(dont_encode, Options, false) of
-        true ->
-            Packet;
-        false ->
-            Msg = #blockchain_state_channel_message_v1_pb{msg = {packet, Packet}},
-            blockchain_state_channel_v1_pb:encode_msg(Msg)
-    end.
-
-join_payload(AppKey, DevNonce) ->
-    MType = ?JOIN_REQ,
-    MHDRRFU = 0,
-    Major = 0,
-    AppEUI = lorawan_utils:reverse(?APPEUI),
-    DevEUI = lorawan_utils:reverse(?DEVEUI),
-    Payload0 = <<MType:3, MHDRRFU:3, Major:2, AppEUI:8/binary, DevEUI:8/binary, DevNonce:2/binary>>,
-    MIC = crypto:macN(cmac, aes_128_cbc, AppKey, Payload0, 4),
-    <<Payload0/binary, MIC:4/binary>>.
-
-frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt) ->
-    frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, #{}).
-
-frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, Options) ->
-    DevAddr = maps:get(devaddr, Options, <<33554431:25/integer-unsigned-little, $H:7/integer>>),
-    Payload1 = frame_payload(MType, DevAddr, NwkSessionKey, AppSessionKey, FCnt, Options),
-    Routing =
-        case maps:get(routing, Options, false) of
-            true ->
-                <<DevNum:32/integer-unsigned-little>> = DevAddr,
-                blockchain_helium_packet_v1:make_routing_info({devaddr, DevNum});
-            false ->
-                undefined
-        end,
-    HeliumPacket = #packet_pb{
-        type = lorawan,
-        payload = Payload1,
-        frequency = 923.3,
-        datarate = maps:get(datarate, Options, <<"SF8BW125">>),
-        signal_strength = maps:get(rssi, Options, 0.0),
-        snr = maps:get(snr, Options, 0.0),
-        routing = Routing
-    },
-    Packet = #blockchain_state_channel_packet_v1_pb{
-        packet = HeliumPacket,
-        hotspot = PubKeyBin,
-        region = maps:get(region, Options, 'US915')
-    },
-    case maps:get(dont_encode, Options, false) of
-        true ->
-            Packet;
-        false ->
-            Msg = #blockchain_state_channel_message_v1_pb{msg = {packet, Packet}},
-            blockchain_state_channel_v1_pb:encode_msg(Msg)
-    end.
-
-frame_payload(MType, DevAddr, NwkSessionKey, AppSessionKey, FCnt, Options) ->
-    OptionsBoolToBit = fun(Key) ->
-        case maps:get(Key, Options, false) of
-            true -> 1;
-            false -> 0
-        end
-    end,
-    MHDRRFU = 0,
-    Major = 0,
-    ADR = OptionsBoolToBit(wants_adr),
-    ADRACKReq = OptionsBoolToBit(wants_adr_ack),
-    ACK = OptionsBoolToBit(wants_ack),
-    RFU = 0,
-    FOptsBin = lorawan_mac_commands:encode_fupopts(maps:get(fopts, Options, [])),
-    FOptsLen = byte_size(FOptsBin),
-    <<Port:8/integer, Body/binary>> = maps:get(body, Options, <<1:8>>),
-    Data = lorawan_utils:reverse(
-        lorawan_utils:cipher(Body, AppSessionKey, MType band 1, DevAddr, FCnt)
-    ),
-    FCntSize = maps:get(fcnt_size, Options, 16),
-    Payload0 =
-        <<MType:3, MHDRRFU:3, Major:2, DevAddr:4/binary, ADR:1, ADRACKReq:1, ACK:1, RFU:1,
-            FOptsLen:4, FCnt:FCntSize/little-unsigned-integer, FOptsBin:FOptsLen/binary,
-            Port:8/integer, Data/binary>>,
-    B0 = router_utils:b0(MType band 1, DevAddr, FCnt, erlang:byte_size(Payload0)),
-    MIC = crypto:macN(cmac, aes_128_cbc, NwkSessionKey, <<B0/binary, Payload0/binary>>, 4),
-    <<Payload0/binary, MIC:4/binary>>.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -978,64 +510,6 @@ nonl([$\n | T]) -> nonl(T);
 nonl([H | T]) -> [H | nonl(T)];
 nonl([]) -> [].
 
-deframe_packet(Packet, SessionKey) ->
-    <<MType:3, _MHDRRFU:3, _Major:2, DevAddr:4/binary, ADR:1, RFU:1, ACK:1, FPending:1, FOptsLen:4,
-        FCnt:16/little-unsigned-integer, FOpts:FOptsLen/binary,
-        PayloadAndMIC/binary>> = Packet#packet_pb.payload,
-    {FPort, FRMPayload} = lorawan_utils:extract_frame_port_payload(PayloadAndMIC),
-    Data = lorawan_utils:reverse(
-        lorawan_utils:cipher(FRMPayload, SessionKey, MType band 1, DevAddr, FCnt)
-    ),
-    ct:pal("FOpts ~p", [FOpts]),
-    #frame{
-        mtype = MType,
-        devaddr = DevAddr,
-        adr = ADR,
-        rfu = RFU,
-        ack = ACK,
-        fpending = FPending,
-        fcnt = FCnt,
-        fopts = lorawan_mac_commands:parse_fdownopts(FOpts),
-        fport = FPort,
-        data = Data
-    }.
-
-deframe_join_packet(
-    #packet_pb{payload = <<MType:3, _MHDRRFU:3, _Major:2, EncPayload/binary>>},
-    DevNonce,
-    AppKey
-) when MType == ?JOIN_ACCEPT ->
-    ct:pal("Enc join ~w", [EncPayload]),
-    Payload = crypto:crypto_one_time(aes_128_ecb, AppKey, EncPayload, true),
-    {AppNonce, NetID, DevAddr, DLSettings, RxDelay, MIC, CFList} =
-        case Payload of
-            <<AN:3/binary, NID:3/binary, DA:4/binary, DL:8/integer-unsigned, RxD:8/integer-unsigned,
-                M:4/binary>> ->
-                CFL = <<>>,
-                {AN, NID, DA, DL, RxD, M, CFL};
-            <<AN:3/binary, NID:3/binary, DA:4/binary, DL:8/integer-unsigned, RxD:8/integer-unsigned,
-                CFL:16/binary, M:4/binary>> ->
-                {AN, NID, DA, DL, RxD, M, CFL}
-        end,
-    ct:pal("Dec join ~w", [Payload]),
-    %{?APPEUI, ?DEVEUI} = {lorawan_utils:reverse(AppEUI0), lorawan_utils:reverse(DevEUI0)},
-    Msg = binary:part(Payload, {0, erlang:byte_size(Payload) - 4}),
-    MIC = crypto:macN(cmac, aes_128_cbc, AppKey, <<MType:3, _MHDRRFU:3, _Major:2, Msg/binary>>, 4),
-    NetID = <<"He2">>,
-    NwkSKey = crypto:crypto_one_time(
-        aes_128_ecb,
-        AppKey,
-        lorawan_utils:padded(16, <<16#01, AppNonce/binary, NetID/binary, DevNonce/binary>>),
-        true
-    ),
-    AppSKey = crypto:crypto_one_time(
-        aes_128_ecb,
-        AppKey,
-        lorawan_utils:padded(16, <<16#02, AppNonce/binary, NetID/binary, DevNonce/binary>>),
-        true
-    ),
-    {NetID, DevAddr, DLSettings, RxDelay, NwkSKey, AppSKey, CFList}.
-
 %%%-------------------------------------------------------------------
 %% @doc
 %%
@@ -1057,3 +531,34 @@ ws_init() ->
             {ok, Pid}
     after 2500 -> ct:fail(websocket_init_timeout)
     end.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+-spec add_oui(non_neg_integer(), list()) -> ok.
+add_oui(OUI, ConsensusMembers) ->
+    {ok, PubKey, SigFun, _} = blockchain_swarm:keys(),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    Chain = blockchain_worker:blockchain(),
+    Ledger = blockchain:ledger(Chain),
+
+    %% Create and submit OUI txn with an empty filter
+    OUI = 1,
+    {Filter, _} = xor16:to_bin(xor16:new([0], fun xxhash:hash64/1)),
+    OUITxn = blockchain_txn_oui_v1:new(OUI, PubKeyBin, [PubKeyBin], Filter, 8),
+    OUITxnFee = blockchain_txn_oui_v1:calculate_fee(OUITxn, Chain),
+    OUITxnStakingFee = blockchain_txn_oui_v1:calculate_staking_fee(OUITxn, Chain),
+    OUITxn0 = blockchain_txn_oui_v1:fee(OUITxn, OUITxnFee),
+    OUITxn1 = blockchain_txn_oui_v1:staking_fee(OUITxn0, OUITxnStakingFee),
+
+    SignedOUITxn = blockchain_txn_oui_v1:sign(OUITxn1, SigFun),
+
+    ?assertEqual({error, not_found}, blockchain_ledger_v1:find_routing(OUI, Ledger)),
+
+    {ok, Block0} = blockchain_test_utils:create_block(ConsensusMembers, [SignedOUITxn]),
+    _ = blockchain_test_utils:add_block(Block0, Chain, self(), blockchain_swarm:tid()),
+
+    ok = test_utils:wait_until(fun() -> {ok, 2} == blockchain:height(Chain) end),
+    ok.


### PR DESCRIPTION
This PR aims to remove the need for P2P swarm to be started for testing and instead use basic Erlang messaging.

It will use a `gen_server` to simulate devices and will also insert itself into an `ets table` to be read by the testing Console.

This should increase reliability of the test suites, execution time and also bring more simplicity.