### PR TITLE
fix xor filter reporting error when not all filters are in use

### DIFF
--- a/src/cli/router_cli_xor_filter.erl
+++ b/src/cli/router_cli_xor_filter.erl
@@ -208,9 +208,13 @@ filter_report(["filter", "report"], [], [{id, ID}]) ->
     report_device(DeviceID);
 filter_report(["filter", "report"], [], []) ->
     [
-        {routing, Routing},
-        {in_memory, Memory}
+        {routing, Routing0},
+        {in_memory, Memory0}
     ] = router_xor_filter_worker:report_filter_sizes(),
+
+    Max = lists:max([length(Routing0), length(Memory0)]),
+    Routing = router_utils:enumerate_0_to_size(Routing0, Max, unused),
+    Memory = router_utils:enumerate_0_to_size(Memory0, Max, unsued),
 
     c_table([
         [

--- a/src/router_utils.erl
+++ b/src/router_utils.erl
@@ -31,7 +31,9 @@
     mtype_to_ack/1,
     frame_timeout/0,
     join_timeout/0,
-    get_env_int/2
+    get_env_int/2,
+    enumerate_0/1,
+    enumerate_0_to_size/3
 ]).
 
 -type uuid_v4() :: binary().
@@ -848,11 +850,28 @@ get_device_traces(DeviceID) ->
 trace_file(<<BinFileName:5/binary, _/binary>>) ->
     BinFileName.
 
+-spec enumerate_0(list(T)) -> list({non_neg_integer(), T}).
+enumerate_0(L) ->
+    lists:zip(lists:seq(0, erlang:length(L) - 1), L).
+
+-spec enumerate_0_to_size(list({integer(), T}), integer(), T) -> list({integer(), T}).
+enumerate_0_to_size(IndexedList, Max, Default) ->
+    Needed = Max - length(IndexedList),
+    {_, Start} = lists:unzip(IndexedList),
+    End = lists:duplicate(Needed, Default),
+    enumerate_0(Start ++ End).
+
 %% ------------------------------------------------------------------
 %% EUNIT Tests
 %% ------------------------------------------------------------------
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+enumerate_0_to_size_test_() ->
+    [
+        ?_assertEqual([{0, default}], enumerate_0_to_size([], 1, default)),
+        ?_assertEqual([{0, zero}, {1, default}], enumerate_0_to_size([{0, zero}], 2, default))
+    ].
 
 trace_test() ->
     application:ensure_all_started(lager),

--- a/src/router_xor_filter_worker.erl
+++ b/src/router_xor_filter_worker.erl
@@ -227,7 +227,8 @@ handle_call(
             {reply, Err, State};
         {ok, Filters, _Routing} ->
             Reply = [
-                {routing, enumerate_0([byte_size(F) || F <- Filters])},
+                {routing,
+                    enumerate_0([byte_size(F) || F <- Filters], maps:size(FilterToDevices), 0)},
                 {in_memory, [
                     {Idx, erlang:length(Devs)}
                  || {Idx, Devs} <- maps:to_list(FilterToDevices)
@@ -1169,6 +1170,11 @@ default_timer() ->
         Str when is_list(Str) -> erlang:list_to_integer(Str);
         I -> I
     end.
+
+-spec enumerate_0(list(T), non_neg_integer(), T) -> list({non_neg_integer(), T}).
+enumerate_0(L0, Max, Default) ->
+    End = lists:duplicate(Max - length(L0), Default),
+    enumerate_0(L0 ++ End).
 
 -spec enumerate_0(list(T)) -> list({non_neg_integer(), T}).
 enumerate_0(L) ->

--- a/test/router_xor_filter_SUITE.erl
+++ b/test/router_xor_filter_SUITE.erl
@@ -24,8 +24,7 @@
     device_add_multiple_send_updates_to_console_test/1,
     device_add_unique_and_matching_send_updates_to_console_test/1,
     device_removed_send_updates_to_console_test/1,
-    estimate_cost_test/1,
-    reporting_test/1
+    estimate_cost_test/1
 ]).
 
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
@@ -79,8 +78,7 @@ all() ->
         device_add_multiple_send_updates_to_console_test,
         device_add_unique_and_matching_send_updates_to_console_test,
         device_removed_send_updates_to_console_test,
-        estimate_cost_test,
-        reporting_test
+        estimate_cost_test
     ].
 
 %%--------------------------------------------------------------------
@@ -1545,32 +1543,6 @@ estimate_cost_test(Config) ->
     ?assertEqual(0, maps:size(State#state.pending_txns)),
     %% should _NOT_ have pushed a new filter to the chain for only removed devices
     ok = expect_block(3, Chain),
-
-    ?assert(meck:validate(blockchain_worker)),
-    meck:unload(blockchain_worker),
-    ok.
-
-reporting_test(_Config) ->
-    %% Init worker
-    application:set_env(router, router_xor_filter_worker, false),
-    erlang:whereis(router_xor_filter_worker) ! post_init,
-
-    %% Wait until xor filter worker started properly
-    ok = test_utils:wait_until(fun() ->
-        State = sys:get_state(router_xor_filter_worker),
-        State#state.chain =/= undefined andalso
-            State#state.oui =/= undefined
-    end),
-
-    %% Ensure reporting returns lists of the same size
-    [
-        {routing, Routing},
-        {in_memory, Memory}
-    ] = router_xor_filter_worker:report_filter_sizes(),
-
-    ?assertEqual(length(Memory), length(Routing), "reports should be the same length"),
-    %% Original thrower of the error
-    _Together = lists:zip(Memory, Routing),
 
     ?assert(meck:validate(blockchain_worker)),
     meck:unload(blockchain_worker),

--- a/test/router_xor_filter_SUITE.erl
+++ b/test/router_xor_filter_SUITE.erl
@@ -24,7 +24,8 @@
     device_add_multiple_send_updates_to_console_test/1,
     device_add_unique_and_matching_send_updates_to_console_test/1,
     device_removed_send_updates_to_console_test/1,
-    estimate_cost_test/1
+    estimate_cost_test/1,
+    reporting_test/1
 ]).
 
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
@@ -78,7 +79,8 @@ all() ->
         device_add_multiple_send_updates_to_console_test,
         device_add_unique_and_matching_send_updates_to_console_test,
         device_removed_send_updates_to_console_test,
-        estimate_cost_test
+        estimate_cost_test,
+        reporting_test
     ].
 
 %%--------------------------------------------------------------------
@@ -1543,6 +1545,32 @@ estimate_cost_test(Config) ->
     ?assertEqual(0, maps:size(State#state.pending_txns)),
     %% should _NOT_ have pushed a new filter to the chain for only removed devices
     ok = expect_block(3, Chain),
+
+    ?assert(meck:validate(blockchain_worker)),
+    meck:unload(blockchain_worker),
+    ok.
+
+reporting_test(_Config) ->
+    %% Init worker
+    application:set_env(router, router_xor_filter_worker, false),
+    erlang:whereis(router_xor_filter_worker) ! post_init,
+
+    %% Wait until xor filter worker started properly
+    ok = test_utils:wait_until(fun() ->
+        State = sys:get_state(router_xor_filter_worker),
+        State#state.chain =/= undefined andalso
+            State#state.oui =/= undefined
+    end),
+
+    %% Ensure reporting returns lists of the same size
+    [
+        {routing, Routing},
+        {in_memory, Memory}
+    ] = router_xor_filter_worker:report_filter_sizes(),
+
+    ?assertEqual(length(Memory), length(Routing), "reports should be the same length"),
+    %% Original thrower of the error
+    _Together = lists:zip(Memory, Routing),
 
     ?assert(meck:validate(blockchain_worker)),
     meck:unload(blockchain_worker),


### PR DESCRIPTION
fixes error
```
RPC to 'router@127.0.0.1' failed: {'EXIT',
                                   {function_clause,
                                    [{lists,zip,
                                      [[{1,0},{2,0},{3,0},{4,0}],[]],
                                      [{file,"lists.erl"},{line,391}]},
                                     {lists,zip,2,
                                      [{file,"lists.erl"},{line,391}]},
                                     {router_cli_xor_filter,filter_report,3,
                                      [{file,
                                        "/opt/router/src/cli/router_cli_xor_filter.erl"},
                                       {line,221}]},
                                     {clique_command,run,1,
```