### PR TITLE
provide short name in string for contains command

### DIFF
--- a/src/cli/router_cli_xor_filter.erl
+++ b/src/cli/router_cli_xor_filter.erl
@@ -88,8 +88,16 @@ filter_cmd() ->
             ["filter", "contains"],
             [],
             [
-                {app, [{longname, "app_eui"}, {typecast, fun erlang:list_to_binary/1}]},
-                {dev, [{longname, "dev_eui"}, {typecast, fun erlang:list_to_binary/1}]}
+                {app_eui, [
+                    {shortname, "app"},
+                    {longname, "app_eui"},
+                    {typecast, fun erlang:list_to_binary/1}
+                ]},
+                {dev_eui, [
+                    {shortname, "dev"},
+                    {longname, "dev_eui"},
+                    {typecast, fun erlang:list_to_binary/1}
+                ]}
             ],
             fun filter_contains/3
         ]


### PR DESCRIPTION
Up to now we've been lucky in that the flag name has always matched the
longname.

{flag key, {shortname, "matches as string"}, {longname, "secondary match as string"}}