### PR TITLE
Fix join devaddr bug 

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -55,3 +55,12 @@ ROUTER_CHARGE_WHEN_NO_OFFER=true
 ROUTER_HOTSPOT_REPUTATION_ENABLED=false
 # Hotspot reputation threshold (see docs/hotspot_reputation.md)
 ROUTER_HOTSPOT_REPUTATION_THRESHOLD=50
+
+# Set resolution at which device addresses are alocated (Default to 3)
+# Ex: resolution 3 holds 41162 indexes and your Router has an OUI with 8 device addresses
+# It means that it can support up to 329296 devices before seeing some potential conflicts.
+# Note:
+#   - Conflicts are still possible but less likely.
+#   - Resolution 3 or 4 is recommended as they will provide big enough hexagons to avoid conflicts.
+# See https://h3geo.org/docs/core-library/restable/ for resolution data
+ROUTER_DEVADDR_ALLOCATE_RESOLUTION=3

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: | $(grpc_services_directory)
 	$(REBAR) fmt --verbose --check "config/{test,sys}.{config,config.src}"
 	$(REBAR) xref
 	$(REBAR) eunit
-	$(REBAR) ct --suite=$(TEST_SUITES)
+	$(REBAR) ct --readable=true --suite=$(TEST_SUITES)
 	$(REBAR) dialyzer
 
 rel: | $(grpc_services_directory)

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -51,7 +51,8 @@
         {downlink_port_0_enabled, "${ROUTER_DOWNLINK_PORT_0_ENABLED}"},
         {charge_when_no_offer, "${ROUTER_CHARGE_WHEN_NO_OFFER}"},
         {hotspot_reputation_enabled, "${ROUTER_HOTSPOT_REPUTATION_ENABLED}"},
-        {hotspot_reputation_threshold, "${ROUTER_HOTSPOT_REPUTATION_THRESHOLD}"}
+        {hotspot_reputation_threshold, "${ROUTER_HOTSPOT_REPUTATION_THRESHOLD}"},
+        {devaddr_allocate_resolution, "${ROUTER_DEVADDR_ALLOCATE_RESOLUTION}"}
     ]},
     {grpcbox, [
         {servers, [

--- a/include/metrics.hrl
+++ b/include/metrics.hrl
@@ -26,6 +26,8 @@
 -define(METRICS_GRPC_CONNECTION_COUNT, "router_grpc_connection_count").
 -define(METRICS_SC_CLOSE_SUBMIT, "router_sc_close_submit_count").
 -define(METRICS_HOTSPOT_REPUTATION, "router_hotspot_reputation_gauge").
+-define(METRICS_DEVICE_TOTAL, "router_device_total_gauge").
+-define(METRICS_DEVICE_RUNNING, "router_device_running_gauge").
 
 -define(METRICS, [
     {?METRICS_DC, prometheus_gauge, [], "Active State Channel balance"},
@@ -55,5 +57,7 @@
     {?METRICS_GRPC_CONNECTION_COUNT, prometheus_gauge, [], "Number of active GRPC Connections"},
     {?METRICS_SC_CLOSE_SUBMIT, prometheus_counter, [status],
         "Router state channels close txn status"},
-    {?METRICS_HOTSPOT_REPUTATION, prometheus_gauge, [hotspot], "Reputation gauge for hotspot"}
+    {?METRICS_HOTSPOT_REPUTATION, prometheus_gauge, [hotspot], "Reputation gauge for hotspot"},
+    {?METRICS_DEVICE_TOTAL, prometheus_gauge, [], "Device total gauge"},
+    {?METRICS_DEVICE_RUNNING, prometheus_gauge, [], "Device running gauge"}
 ]).

--- a/include/router_device.hrl
+++ b/include/router_device.hrl
@@ -1,3 +1,25 @@
+-record(device_v7, {
+    id :: binary() | undefined,
+    name :: binary() | undefined,
+    dev_eui :: binary() | undefined,
+    app_eui :: binary() | undefined,
+    %% {nwk_s_key, app_s_key}
+    keys = [] :: list({binary() | undefined, binary() | undefined}),
+    devaddrs = [] :: [binary()],
+    dev_nonces = [] :: [binary()],
+    fcnt = 0 :: non_neg_integer(),
+    fcntdown = 0 :: non_neg_integer(),
+    offset = 0 :: non_neg_integer(),
+    channel_correction = false :: boolean(),
+    queue = [] :: [any()],
+    region :: atom() | undefined,
+    last_known_datarate :: integer() | undefined,
+    ecc_compact :: map(),
+    location :: libp2p_crypto:pubkey_bin() | undefined,
+    metadata = #{} :: map(),
+    is_active = true :: boolean()
+}).
+
 -record(device_v6, {
     id :: binary() | undefined,
     name :: binary() | undefined,

--- a/src/device/router_device.erl
+++ b/src/device/router_device.erl
@@ -135,7 +135,7 @@ devaddrs(Device) ->
 
 -spec devaddrs([binary()], device()) -> device().
 devaddrs(Devaddrs, Device) ->
-    Device#device_v7{devaddrs = Devaddrs}.
+    Device#device_v7{devaddrs = lists:sublist(Devaddrs, 25)}.
 
 -spec dev_nonces(device()) -> [binary()].
 dev_nonces(Device) ->

--- a/src/device/router_device.erl
+++ b/src/device/router_device.erl
@@ -246,7 +246,7 @@ is_active(IsActive, Device) ->
 
 -spec preferred_hotspots(device()) -> [libp2p_crypto:pubkey_bin()].
 preferred_hotspots(Device) ->
-    maps:get(preferred_hotspots, Device#device_v6.metadata, []).
+    maps:get(preferred_hotspots, Device#device_v7.metadata, []).
 
 -spec update([{atom(), any()}], device()) -> device().
 update([], Device) ->

--- a/src/device/router_device.erl
+++ b/src/device/router_device.erl
@@ -24,7 +24,8 @@
     keys/1, keys/2,
     nwk_s_key/1,
     app_s_key/1,
-    devaddr/1, devaddr/2,
+    devaddr/1,
+    devaddrs/1, devaddrs/2,
     dev_nonces/1, dev_nonces/2,
     fcnt/1, fcnt/2,
     fcntdown/1, fcntdown/2,
@@ -58,7 +59,7 @@
 
 -define(QUEUE_SIZE_LIMIT, 20).
 
--type device() :: #device_v6{}.
+-type device() :: #device_v7{}.
 
 -export_type([device/0]).
 
@@ -68,137 +69,144 @@
 
 -spec new(binary()) -> device().
 new(ID) ->
-    #device_v6{
+    #device_v7{
         id = ID,
         ecc_compact = libp2p_crypto:generate_keys(ecc_compact)
     }.
 
 -spec id(device()) -> binary() | undefined.
 id(Device) ->
-    Device#device_v6.id.
+    Device#device_v7.id.
 
 -spec name(device()) -> binary() | undefined.
 name(Device) ->
-    Device#device_v6.name.
+    Device#device_v7.name.
 
 -spec name(binary(), device()) -> device().
 name(Name, Device) ->
-    Device#device_v6{name = Name}.
+    Device#device_v7{name = Name}.
 
 -spec app_eui(device()) -> binary() | undefined.
 app_eui(Device) ->
-    Device#device_v6.app_eui.
+    Device#device_v7.app_eui.
 
 -spec app_eui(binary(), device()) -> device().
 app_eui(EUI, Device) ->
-    Device#device_v6{app_eui = EUI}.
+    Device#device_v7{app_eui = EUI}.
 
 -spec dev_eui(device()) -> binary() | undefined.
 dev_eui(Device) ->
-    Device#device_v6.dev_eui.
+    Device#device_v7.dev_eui.
 
 -spec dev_eui(binary(), device()) -> device().
 dev_eui(EUI, Device) ->
-    Device#device_v6{dev_eui = EUI}.
+    Device#device_v7{dev_eui = EUI}.
 
 -spec keys(device()) -> list({binary() | undefined, binary() | undefined}).
-keys(#device_v6{keys = Keys}) ->
+keys(#device_v7{keys = Keys}) ->
     Keys.
 
 -spec keys(list({binary(), binary()}), device()) -> device().
 keys(Keys, Device) ->
-    Device#device_v6{keys = lists:sublist(Keys, 25)}.
+    Device#device_v7{keys = lists:sublist(Keys, 25)}.
 
 -spec nwk_s_key(device()) -> binary() | undefined.
-nwk_s_key(#device_v6{keys = []}) ->
+nwk_s_key(#device_v7{keys = []}) ->
     undefined;
-nwk_s_key(#device_v6{keys = [{NwkSKey, _AppSKey} | _]}) ->
+nwk_s_key(#device_v7{keys = [{NwkSKey, _AppSKey} | _]}) ->
     NwkSKey.
 
 -spec app_s_key(device()) -> binary() | undefined.
-app_s_key(#device_v6{keys = []}) ->
+app_s_key(#device_v7{keys = []}) ->
     undefined;
-app_s_key(#device_v6{keys = [{_NwkSKey, AppSKey} | _]}) ->
+app_s_key(#device_v7{keys = [{_NwkSKey, AppSKey} | _]}) ->
     AppSKey.
 
 -spec devaddr(device()) -> binary() | undefined.
 devaddr(Device) ->
-    Device#device_v6.devaddr.
+    case Device#device_v7.devaddrs of
+        [] -> undefined;
+        [D | _] -> D
+    end.
 
--spec devaddr(binary(), device()) -> device().
-devaddr(Devaddr, Device) ->
-    Device#device_v6{devaddr = Devaddr}.
+-spec devaddrs(device()) -> [binary()].
+devaddrs(Device) ->
+    Device#device_v7.devaddrs.
+
+-spec devaddrs([binary()], device()) -> device().
+devaddrs(Devaddrs, Device) ->
+    Device#device_v7{devaddrs = Devaddrs}.
 
 -spec dev_nonces(device()) -> [binary()].
 dev_nonces(Device) ->
-    Device#device_v6.dev_nonces.
+    Device#device_v7.dev_nonces.
 
 -spec dev_nonces([binary()], device()) -> device().
 dev_nonces(Nonces, Device) ->
-    Device#device_v6{dev_nonces = lists:sublist(Nonces, 25)}.
+    Device#device_v7{dev_nonces = lists:sublist(Nonces, 25)}.
 
 -spec fcnt(device()) -> non_neg_integer().
 fcnt(Device) ->
-    Device#device_v6.fcnt.
+    Device#device_v7.fcnt.
 
 -spec fcnt(non_neg_integer(), device()) -> device().
 fcnt(Fcnt, Device) ->
-    Device#device_v6{fcnt = Fcnt}.
+    Device#device_v7{fcnt = Fcnt}.
 
 -spec fcntdown(device()) -> non_neg_integer().
 fcntdown(Device) ->
-    Device#device_v6.fcntdown.
+    Device#device_v7.fcntdown.
 
 -spec fcntdown(non_neg_integer(), device()) -> device().
 fcntdown(Fcnt, Device) ->
-    Device#device_v6{fcntdown = Fcnt}.
+    Device#device_v7{fcntdown = Fcnt}.
 
 -spec offset(device()) -> non_neg_integer().
 offset(Device) ->
-    Device#device_v6.offset.
+    Device#device_v7.offset.
 
 -spec offset(non_neg_integer(), device()) -> device().
 offset(Offset, Device) ->
-    Device#device_v6{offset = Offset}.
+    Device#device_v7{offset = Offset}.
 
 -spec channel_correction(device()) -> boolean().
 channel_correction(Device) ->
-    Device#device_v6.channel_correction.
+    Device#device_v7.channel_correction.
 
 -spec channel_correction(boolean(), device()) -> device().
 channel_correction(Correct, Device) ->
-    Device#device_v6{channel_correction = Correct}.
+    Device#device_v7{channel_correction = Correct}.
 
 -spec queue(device()) -> [#downlink{} | any()].
 queue(Device) ->
-    Device#device_v6.queue.
+    Device#device_v7.queue.
 
 -spec queue([#downlink{}], device()) -> device().
 queue(Q, Device) ->
-    Device#device_v6{queue = Q}.
+    Device#device_v7{queue = Q}.
 
 -spec region(device()) -> atom().
 region(Device) ->
-    Device#device_v6.region.
+    Device#device_v7.region.
 
 -spec region(atom(), device()) -> device().
 region(Region, Device) ->
-    Device#device_v6{region = Region}.
+    Device#device_v7{region = Region}.
 
 -spec last_known_datarate(device()) -> integer().
 last_known_datarate(Device) ->
-    Device#device_v6.last_known_datarate.
+    Device#device_v7.last_known_datarate.
 
 -spec last_known_datarate(integer(), device()) -> device().
 last_known_datarate(DR, Device) ->
-    Device#device_v6{last_known_datarate = DR}.
+    Device#device_v7{last_known_datarate = DR}.
 
 -spec ecc_compact(device()) -> map().
 ecc_compact(Device) ->
     %% NOTE: https://github.com/erlang/otp/commit/37a58368d7876e325710a4c269f0af27b40434c6#diff-b190dfbfb70f8d4c5a3c13699d85f65523bf79dd630117ccf6cd535ee6945996
     %% That commit to OTP/24 added another field to the #'ECPrivateKey'{} record.
     %% Until we can update all of them in our db, let's upgrade to the new record when they're requested.
-    case Device#device_v6.ecc_compact of
+    case Device#device_v7.ecc_compact of
         #{secret := {ecc_compact, {'ECPrivateKey', Version, PrivKey, Params, PubKey}}} = Map ->
             Map#{
                 secret =>
@@ -210,31 +218,31 @@ ecc_compact(Device) ->
 
 -spec ecc_compact(map(), device()) -> device().
 ecc_compact(Keys, Device) ->
-    Device#device_v6{ecc_compact = Keys}.
+    Device#device_v7{ecc_compact = Keys}.
 
 -spec location(device()) -> libp2p_crypto:pubkey_bin() | undefined.
 location(Device) ->
-    Device#device_v6.location.
+    Device#device_v7.location.
 
 -spec location(libp2p_crypto:pubkey_bin() | undefined, device()) -> device().
 location(PubkeyBin, Device) ->
-    Device#device_v6{location = PubkeyBin}.
+    Device#device_v7{location = PubkeyBin}.
 
 -spec metadata(device()) -> map().
 metadata(Device) ->
-    Device#device_v6.metadata.
+    Device#device_v7.metadata.
 
 -spec metadata(map(), device()) -> device().
-metadata(Meta1, #device_v6{metadata = Meta0} = Device) ->
-    Device#device_v6{metadata = maps:merge(Meta0, Meta1)}.
+metadata(Meta1, #device_v7{metadata = Meta0} = Device) ->
+    Device#device_v7{metadata = maps:merge(Meta0, Meta1)}.
 
 -spec is_active(device()) -> boolean().
 is_active(Device) ->
-    Device#device_v6.is_active.
+    Device#device_v7.is_active.
 
 -spec is_active(boolean(), device()) -> device().
 is_active(IsActive, Device) ->
-    Device#device_v6{is_active = IsActive}.
+    Device#device_v7{is_active = IsActive}.
 
 -spec preferred_hotspots(device()) -> [libp2p_crypto:pubkey_bin()].
 preferred_hotspots(Device) ->
@@ -251,8 +259,8 @@ update([{dev_eui, Value} | T], Device) ->
     update(T, ?MODULE:dev_eui(Value, Device));
 update([{keys, Value} | T], Device) ->
     update(T, ?MODULE:keys(Value, Device));
-update([{devaddr, Value} | T], Device) ->
-    update(T, ?MODULE:devaddr(Value, Device));
+update([{devaddrs, Value} | T], Device) ->
+    update(T, ?MODULE:devaddrs(Value, Device));
 update([{dev_nonces, Value} | T], Device) ->
     update(T, ?MODULE:dev_nonces(Value, Device));
 update([{fcnt, Value} | T], Device) ->
@@ -287,16 +295,47 @@ deserialize(Binary) ->
     case erlang:binary_to_term(Binary) of
         %% TODO promote `rx_delay' out of `metadata', so metadata can
         %% then merely signal when Console changed that value.
+        #device_v7{} = V7 ->
+            V7;
         #device_v6{} = V6 ->
-            V6;
+            Devaddrs =
+                case V6#device_v6.devaddr of
+                    undefined -> [];
+                    DevAddr -> [DevAddr]
+                end,
+            #device_v7{
+                id = V6#device_v6.id,
+                name = V6#device_v6.name,
+                dev_eui = V6#device_v6.dev_eui,
+                app_eui = V6#device_v6.app_eui,
+                keys = V6#device_v6.keys,
+                devaddrs = Devaddrs,
+                dev_nonces = V6#device_v6.dev_nonces,
+                fcnt = V6#device_v6.fcnt,
+                fcntdown = V6#device_v6.fcntdown,
+                offset = V6#device_v6.offset,
+                channel_correction = V6#device_v6.channel_correction,
+                queue = V6#device_v6.queue,
+                region = undefined,
+                last_known_datarate = undefined,
+                ecc_compact = V6#device_v6.ecc_compact,
+                location = V6#device_v6.location,
+                metadata = V6#device_v6.metadata,
+                is_active = V6#device_v6.is_active
+            };
         #device_v5{} = V5 ->
-            #device_v6{
+            Devaddrs =
+                case V5#device_v5.devaddr of
+                    undefined -> [];
+                    DevAddr -> [DevAddr]
+                end,
+            #device_v7{
                 id = V5#device_v5.id,
                 name = V5#device_v5.name,
                 dev_eui = V5#device_v5.dev_eui,
                 app_eui = V5#device_v5.app_eui,
                 keys = V5#device_v5.keys,
-                devaddr = V5#device_v5.devaddr,
+                devaddrs = Devaddrs,
                 dev_nonces = V5#device_v5.dev_nonces,
                 fcnt = V5#device_v5.fcnt,
                 fcntdown = V5#device_v5.fcntdown,
@@ -311,13 +350,18 @@ deserialize(Binary) ->
                 is_active = V5#device_v5.is_active
             };
         #device_v4{} = V4 ->
-            #device_v6{
+            Devaddrs =
+                case V4#device_v4.devaddr of
+                    undefined -> [];
+                    DevAddr -> [DevAddr]
+                end,
+            #device_v7{
                 id = V4#device_v4.id,
                 name = V4#device_v4.name,
                 dev_eui = V4#device_v4.dev_eui,
                 app_eui = V4#device_v4.app_eui,
                 keys = [{V4#device_v4.nwk_s_key, V4#device_v4.app_s_key}],
-                devaddr = V4#device_v4.devaddr,
+                devaddrs = Devaddrs,
                 dev_nonces = [V4#device_v4.join_nonce],
                 fcnt = V4#device_v4.fcnt,
                 fcntdown = V4#device_v4.fcntdown,
@@ -332,13 +376,18 @@ deserialize(Binary) ->
                 is_active = V4#device_v4.is_active
             };
         #device_v3{} = V3 ->
-            #device_v6{
+            Devaddrs =
+                case V3#device_v3.devaddr of
+                    undefined -> [];
+                    DevAddr -> [DevAddr]
+                end,
+            #device_v7{
                 id = V3#device_v3.id,
                 name = V3#device_v3.name,
                 dev_eui = V3#device_v3.dev_eui,
                 app_eui = V3#device_v3.app_eui,
                 keys = [{V3#device_v3.nwk_s_key, V3#device_v3.app_s_key}],
-                devaddr = V3#device_v3.devaddr,
+                devaddrs = Devaddrs,
                 dev_nonces = [V3#device_v3.join_nonce],
                 fcnt = V3#device_v3.fcnt,
                 fcntdown = V3#device_v3.fcntdown,
@@ -353,13 +402,13 @@ deserialize(Binary) ->
                 is_active = true
             };
         #device_v2{} = V2 ->
-            #device_v6{
+            #device_v7{
                 id = V2#device_v2.id,
                 name = V2#device_v2.name,
                 dev_eui = V2#device_v2.dev_eui,
                 app_eui = V2#device_v2.app_eui,
                 keys = [{V2#device_v2.nwk_s_key, V2#device_v2.app_s_key}],
-                devaddr = undefined,
+                devaddrs = [],
                 dev_nonces = [V2#device_v2.join_nonce],
                 fcnt = V2#device_v2.fcnt,
                 fcntdown = V2#device_v2.fcntdown,
@@ -379,13 +428,13 @@ deserialize(Binary) ->
                     undefined -> libp2p_crypto:generate_keys(ecc_compact);
                     Key -> Key
                 end,
-            #device_v6{
+            #device_v7{
                 id = V1#device_v1.id,
                 name = V1#device_v1.name,
                 dev_eui = V1#device_v1.dev_eui,
                 app_eui = V1#device_v1.app_eui,
                 keys = [{V1#device_v1.nwk_s_key, V1#device_v1.app_s_key}],
-                devaddr = undefined,
+                devaddrs = [],
                 dev_nonces = [V1#device_v1.join_nonce],
                 fcnt = V1#device_v1.fcnt,
                 fcntdown = V1#device_v1.fcntdown,
@@ -399,13 +448,13 @@ deserialize(Binary) ->
                 is_active = true
             };
         #device{} = V0 ->
-            #device_v6{
+            #device_v7{
                 id = V0#device.id,
                 name = V0#device.name,
                 dev_eui = V0#device.dev_eui,
                 app_eui = V0#device.app_eui,
                 keys = [{V0#device.nwk_s_key, V0#device.app_s_key}],
-                devaddr = undefined,
+                devaddrs = [],
                 dev_nonces = [V0#device.join_nonce],
                 fcnt = V0#device.fcnt,
                 fcntdown = V0#device.fcntdown,
@@ -428,7 +477,7 @@ deserialize(Binary) ->
         MaxSize :: non_neg_integer(),
         Datarate :: integer()
     }.
-can_queue_payload(_Payload, undefined, #device_v6{region = undefined}) ->
+can_queue_payload(_Payload, undefined, #device_v7{region = undefined}) ->
     {error, device_region_unknown};
 can_queue_payload(Payload, DownlinkRegion, Device) ->
     Queue = ?MODULE:queue(Device),
@@ -532,7 +581,7 @@ new_test() ->
     meck:new(libp2p_crypto, [passthrough]),
     meck:expect(libp2p_crypto, generate_keys, fun(ecc_compact) -> Keys end),
 
-    ?assertEqual(#device_v6{id = <<"id">>, ecc_compact = Keys}, new(<<"id">>)),
+    ?assertEqual(#device_v7{id = <<"id">>, ecc_compact = Keys}, new(<<"id">>)),
 
     ?assert(meck:validate(libp2p_crypto)),
     meck:unload(libp2p_crypto).
@@ -576,10 +625,10 @@ app_s_key_test() ->
         app_s_key(keys([{<<"nwk_s_key">>, <<"app_s_key">>}], Device))
     ).
 
-devaddr_test() ->
+devaddrs_test() ->
     Device = new(<<"id">>),
-    ?assertEqual(undefined, devaddr(Device)),
-    ?assertEqual(<<"devaddr">>, devaddr(devaddr(<<"devaddr">>, Device))).
+    ?assertEqual([], devaddrs(Device)),
+    ?assertEqual([<<"devaddrs">>], devaddrs(devaddrs([<<"devaddrs">>], Device))).
 
 dev_nonces_test() ->
     Device = new(<<"id">>),
@@ -638,7 +687,7 @@ update_test() ->
         {app_eui, <<"app_eui">>},
         {dev_eui, <<"dev_eui">>},
         {keys, [{<<"nwk_s_key">>, <<"app_s_key">>}]},
-        {devaddr, <<"devaddr">>},
+        {devaddrs, [<<"devaddr">>]},
         {dev_nonces, [<<"1">>]},
         {fcnt, 1},
         {fcntdown, 1},
@@ -652,13 +701,13 @@ update_test() ->
         {metadata, #{a => b}},
         {is_active, false}
     ],
-    UpdatedDevice = #device_v6{
+    UpdatedDevice = #device_v7{
         id = <<"id">>,
         name = <<"name">>,
         app_eui = <<"app_eui">>,
         dev_eui = <<"dev_eui">>,
         keys = [{<<"nwk_s_key">>, <<"app_s_key">>}],
-        devaddr = <<"devaddr">>,
+        devaddrs = [<<"devaddr">>],
         dev_nonces = [<<"1">>],
         fcnt = 1,
         fcntdown = 1,
@@ -704,9 +753,10 @@ upgrade_test() ->
     {ok, DB, [_, CF]} = router_db:get(),
 
     DeviceID = <<"id">>,
-    V6Device = #device_v6{
+    V7Device = #device_v7{
         id = DeviceID,
         keys = [{undefined, undefined}],
+        devaddrs = [],
         ecc_compact = Keys,
         dev_nonces = [<<>>],
         region = undefined,
@@ -715,38 +765,48 @@ upgrade_test() ->
 
     V0Device = #device{id = DeviceID},
     ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V0Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
 
     V1Device = #device_v1{id = DeviceID},
     ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V1Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
 
     V2Device = #device_v2{id = DeviceID, keys = Keys},
     ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V2Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
 
     V3Device = #device_v3{id = DeviceID, keys = Keys},
     ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V3Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
 
     V4Device = #device_v4{id = DeviceID, keys = Keys},
     ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V4Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
 
     V5Device = #device_v5{
         id = DeviceID,
-        keys = V6Device#device_v6.keys,
+        keys = V7Device#device_v7.keys,
         ecc_compact = Keys,
         dev_nonces = [<<>>]
     },
     ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V5Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
+
+    V6Device = #device_v6{
+        id = DeviceID,
+        keys = V7Device#device_v7.keys,
+        ecc_compact = Keys,
+        dev_nonces = [<<>>]
+    },
+    ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V6Device), []),
+    ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
+    ?assertEqual([V7Device], get(DB, CF)),
 
     V6Device = #device_v6{
         id = DeviceID,

--- a/src/device/router_device.erl
+++ b/src/device/router_device.erl
@@ -808,16 +808,6 @@ upgrade_test() ->
     ?assertEqual({ok, V7Device}, get_by_id(DB, CF, DeviceID)),
     ?assertEqual([V7Device], get(DB, CF)),
 
-    V6Device = #device_v6{
-        id = DeviceID,
-        keys = V6Device#device_v6.keys,
-        ecc_compact = Keys,
-        dev_nonces = [<<>>]
-    },
-    ok = rocksdb:put(DB, CF, <<DeviceID/binary>>, ?MODULE:serialize(V6Device), []),
-    ?assertEqual({ok, V6Device}, get_by_id(DB, CF, DeviceID)),
-    ?assertEqual([V6Device], get(DB, CF)),
-
     gen_server:stop(Pid),
     ?assert(meck:validate(libp2p_crypto)),
     meck:unload(libp2p_crypto).

--- a/src/device/router_device_cache.erl
+++ b/src/device/router_device_cache.erl
@@ -17,10 +17,11 @@
 %% ------------------------------------------------------------------
 -export([
     init/0,
+    get/0, get/1,
+    get_by_devaddr/1,
     save/1,
     delete/1,
-    get/0, get/1,
-    get_by_devaddr/1
+    size/0
 ]).
 
 %% ------------------------------------------------------------------
@@ -83,6 +84,10 @@ save(Device) ->
 delete(DeviceID) ->
     true = ets:delete(?ETS, DeviceID),
     ok.
+
+-spec size() -> non_neg_integer().
+size() ->
+    proplists:get_value(size, ets:info(router_device_cache_ets), 0).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/device/router_device_cache.erl
+++ b/src/device/router_device_cache.erl
@@ -10,6 +10,7 @@
 -include("router_device.hrl").
 
 -define(ETS, router_device_cache_ets).
+-define(DEVADDR_ETS, router_device_cache_devaddr_ets).
 
 %% ------------------------------------------------------------------
 %% API Exports
@@ -28,14 +29,20 @@
 
 -spec init() -> ok.
 init() ->
-    Opts = [
+    _ = ets:new(?ETS, [
         public,
         named_table,
         set,
         {write_concurrency, true},
         {read_concurrency, true}
-    ],
-    _ = ets:new(?ETS, Opts),
+    ]),
+    _ = ets:new(?DEVADDR_ETS, [
+        public,
+        named_table,
+        bag,
+        {write_concurrency, true},
+        {read_concurrency, true}
+    ]),
     ok = init_from_db(),
     ok.
 
@@ -52,13 +59,24 @@ get(DeviceID) ->
 
 -spec get_by_devaddr(binary()) -> [router_device:device()].
 get_by_devaddr(DevAddr) ->
-    MS = ets:fun2ms(fun({_, D}) when D#device_v6.devaddr == DevAddr -> D end),
-    ets:select(?ETS, MS).
+    case ets:lookup(?DEVADDR_ETS, DevAddr) of
+        [] -> [];
+        List -> [Device || {_DevAddr, Device} <- List]
+    end.
 
 -spec save(router_device:device()) -> {ok, router_device:device()}.
 save(Device) ->
     DeviceID = router_device:id(Device),
     true = ets:insert(?ETS, {DeviceID, Device}),
+    % MS = ets:fun2ms(fun({_, D}) when D#device_v7.id == DeviceID -> true end),
+    MS = [{{'_', '$1'}, [{'==', {element, 2, '$1'}, {const, DeviceID}}], [true]}],
+    _ = ets:select_delete(?DEVADDR_ETS, MS),
+    lists:foreach(
+        fun(DevAddr) ->
+            true = ets:insert(?DEVADDR_ETS, {DevAddr, Device})
+        end,
+        router_device:devaddrs(Device)
+    ),
     {ok, Device}.
 
 -spec delete(binary()) -> ok.
@@ -88,15 +106,45 @@ init_from_db_test() ->
     {ok, Pid} = router_db:start_link([Dir]),
     ok = init(),
     ID = router_utils:uuid_v4(),
-    Device = router_device:new(ID),
-
+    Device0 = router_device:new(ID),
+    DevAddr0 = <<"devaddr0">>,
+    Updates = [
+        {name, <<"name">>},
+        {app_eui, <<"app_eui">>},
+        {dev_eui, <<"dev_eui">>},
+        {keys, [{<<"nwk_s_key">>, <<"app_s_key">>}]},
+        {devaddrs, [DevAddr0]},
+        {dev_nonces, [<<"1">>]},
+        {fcnt, 1},
+        {fcntdown, 1},
+        {offset, 1},
+        {channel_correction, true},
+        {queue, [a]},
+        {region, 'US915'},
+        {last_known_datarate, 7},
+        {ecc_compact, #{}},
+        {location, <<"location">>},
+        {metadata, #{a => b}},
+        {is_active, false}
+    ],
+    Device1 = router_device:update(Updates, Device0),
     {ok, DB, [_, CF]} = router_db:get(),
-    ?assertEqual({ok, Device}, router_device:save(DB, CF, Device)),
+    ?assertEqual({ok, Device1}, router_device:save(DB, CF, Device1)),
     ?assertEqual(ok, init_from_db()),
-    ?assertEqual({ok, Device}, ?MODULE:get(ID)),
+    ?assertEqual({ok, Device1}, ?MODULE:get(ID)),
+    ?assertEqual([Device1], ?MODULE:get_by_devaddr(DevAddr0)),
+
+    DevAddr1 = <<"devaddr1">>,
+    DevAddr2 = <<"devaddr2">>,
+    Device2 = router_device:devaddrs([DevAddr1, DevAddr2], Device1),
+    ?assertEqual({ok, Device2}, ?MODULE:save(Device2)),
+    ?assertEqual([], ?MODULE:get_by_devaddr(DevAddr0)),
+    ?assertEqual([Device2], ?MODULE:get_by_devaddr(DevAddr1)),
+    ?assertEqual([Device2], ?MODULE:get_by_devaddr(DevAddr2)),
 
     gen_server:stop(Pid),
     ets:delete(?ETS),
+    ets:delete(?DEVADDR_ETS),
     ok.
 
 get_save_delete_test() ->
@@ -106,14 +154,15 @@ get_save_delete_test() ->
     ID = router_utils:uuid_v4(),
     Device = router_device:new(ID),
 
-    ?assertEqual({ok, Device}, save(Device)),
+    ?assertEqual({ok, Device}, ?MODULE:save(Device)),
     ?assertEqual({ok, Device}, ?MODULE:get(ID)),
     ?assertEqual([Device], ?MODULE:get()),
-    ?assertEqual(ok, delete(ID)),
+    ?assertEqual(ok, ?MODULE:delete(ID)),
     ?assertEqual({error, not_found}, ?MODULE:get(ID)),
 
     gen_server:stop(Pid),
     ets:delete(?ETS),
+    ets:delete(?DEVADDR_ETS),
     ok.
 
 -endif.

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -143,7 +143,7 @@ handle_call(
             {ok, IA} -> IA
         end,
     Parent = h3:to_geo(
-        h3:parent(Index, application:get_env(router, devaddr_allocate_resolution, 1))
+        h3:parent(Index, router_utils:get_env_int(devaddr_allocate_resolution, 3))
     ),
     {NthSubnet, DevaddrBase} =
         case maps:get(Parent, Used, undefined) of

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -142,7 +142,9 @@ handle_call(
             {error, _} -> h3:from_geo({0.0, 0.0}, 12);
             {ok, IA} -> IA
         end,
-    Parent = h3:to_geo(h3:parent(Index, 1)),
+    Parent = h3:to_geo(
+        h3:parent(Index, application:get_env(router, devaddr_allocate_resolution, 1))
+    ),
     {NthSubnet, DevaddrBase} =
         case maps:get(Parent, Used, undefined) of
             undefined ->

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -984,6 +984,7 @@ get_device_for_offer(Offer, DevAddr, PubKeyBin, Chain) ->
                 [] ->
                     {error, ?DEVADDR_NO_DEVICE};
                 [Device | _] ->
+                    %TODO: X% chance of buying packet
                     lager:debug(
                         "best guess device for offer [hash: ~p] [device_id: ~p] [pubkeybin: ~p]",
                         [PHash, router_device:id(Device), PubKeyBin]

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -452,6 +452,9 @@ packet_offer_(Offer, Pid, Chain) ->
                                     ),
                                     {error, ?LATE_PACKET}
                             end;
+                        {ok, _OtherDeviceID, _PacketTime} ->
+                            %% TODO: switch back to other
+                            {ok, Device};
                         {error, not_found} ->
                             check_device_preferred_hotspots(Device, Offer)
                     end;
@@ -841,8 +844,8 @@ send_to_device_worker(
         {error, _Reason1} = Error ->
             router_metrics:packet_routing_error(packet, device_not_found),
             lager:warning(
-                "unable to find device for packet [devaddr: ~p] [gateway: ~p]",
-                [DevAddr, libp2p_crypto:bin_to_b58(PubKeyBin)]
+                "unable to find device for packet [devaddr: ~p / ~p] [gateway: ~p]",
+                [DevAddr, lorawan_utils:binary_to_hex(DevAddr), libp2p_crypto:bin_to_b58(PubKeyBin)]
             ),
             Error;
         {Device, NwkSKey} ->

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -916,6 +916,7 @@ find_device(PubKeyBin, DevAddr, MIC, Payload, Chain) ->
         {error, _} = Error ->
             Error;
         undefined ->
+            ok = router_hotspot_reputation:track_unknown_device(PubKeyBin),
             {error, {unknown_device, DevAddr}};
         {Device, NwkSKey} ->
             {Device, NwkSKey}

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -712,7 +712,8 @@ packet(
                         false ->
                             {error, {?DEVADDR_NOT_IN_SUBNET, DevAddr}}
                     end;
-                _ ->
+                _E ->
+                    lager:warning("fail to find routing ~p", [_E]),
                     %% TODO: Should fail here
                     %% no subnets
                     send_to_device_worker(
@@ -728,7 +729,8 @@ packet(
                         Chain
                     )
             catch
-                _:_ ->
+                _E:_S ->
+                    lager:warning("crashed ~p", [{_E, _S}]),
                     %% TODO: Should fail here
                     %% no subnets
                     send_to_device_worker(

--- a/src/device/router_device_stats.erl
+++ b/src/device/router_device_stats.erl
@@ -1,0 +1,215 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% == Router Device Stats ==
+%%% @end
+%%%-------------------------------------------------------------------
+-module(router_device_stats).
+
+-define(ETS, router_device_stats_ets).
+-define(OFFER_ETS, router_device_stats_offers_ets).
+-define(DEFAULT_TIMER, timer:minutes(2)).
+
+%% ------------------------------------------------------------------
+%% API Exports
+%% ------------------------------------------------------------------
+-export([
+    init/0,
+    track_offer/2,
+    track_packet/3,
+    lookup_hotspot/1,
+    lookup_device/1,
+    cleanup_offers/1
+]).
+
+%% ------------------------------------------------------------------
+%% API Functions
+%% ------------------------------------------------------------------
+
+-spec init() -> ok.
+init() ->
+    Opts1 = [
+        public,
+        named_table,
+        set,
+        {read_concurrency, true}
+    ],
+    _ = ets:new(?ETS, Opts1),
+    Opts2 = [
+        public,
+        named_table,
+        set,
+        {write_concurrency, true},
+        {read_concurrency, true}
+    ],
+    _ = ets:new(?OFFER_ETS, Opts2),
+    ok = spawn_cleanup_offers(?DEFAULT_TIMER),
+    ok.
+
+-spec track_offer(
+    Offer :: blockchain_state_channel_offer_v1:offer(), Device :: router_device:device()
+) -> ok.
+track_offer(Offer, Device) ->
+    erlang:spawn(fun() ->
+        Hotspot = blockchain_state_channel_offer_v1:hotspot(Offer),
+        PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
+        Now = erlang:system_time(millisecond),
+        true = ets:insert(?OFFER_ETS, {{Hotspot, PHash}, router_device:id(Device), Now})
+    end),
+    ok.
+
+-spec track_packet(
+    Packet :: blockchain_helium_packet_v1:packet(),
+    Hotspot :: libp2p_crypto:pubkey_bin(),
+    Device :: router_device:device()
+) -> ok.
+track_packet(Packet, Hotspot, Device) ->
+    erlang:spawn(fun() ->
+        PHash = blockchain_helium_packet_v1:packet_hash(Packet),
+        DeviceID = router_device:id(Device),
+        case ets:lookup(?OFFER_ETS, {Hotspot, PHash}) of
+            [{{Hotspot, PHash}, DeviceID, _Time}] ->
+                true = ets:delete(?OFFER_ETS, {Hotspot, PHash});
+            [{{Hotspot, PHash}, _OtherDeviceID, _Time}] ->
+                _ = ets:update_counter(?ETS, {DeviceID, Hotspot}, {2, 1}, {default, 0});
+            [] ->
+                ok
+        end
+    end),
+    ok.
+
+-spec lookup_hotspot(Hotspot :: any()) -> list().
+lookup_hotspot(Hotspot) ->
+    MS = [{{{'$1', '$2'}, '$3'}, [{'==', '$2', Hotspot}], ['$_']}],
+    [
+        {D, blockchain_utils:addr2name(H), libp2p_crypto:bin_to_b58(H), C}
+     || {{D, H}, C} <- ets:select(?ETS, MS)
+    ].
+
+-spec lookup_device(DeviceID :: router_device:id()) -> list().
+lookup_device(DeviceID) ->
+    MS = [{{{'$1', '$2'}, '$3'}, [{'==', '$1', DeviceID}], ['$_']}],
+    [
+        {D, blockchain_utils:addr2name(H), libp2p_crypto:bin_to_b58(H), C}
+     || {{D, H}, C} <- ets:select(?ETS, MS)
+    ].
+
+-spec cleanup_offers(Timer :: non_neg_integer()) -> ok.
+cleanup_offers(Timer) ->
+    Now = erlang:system_time(millisecond) - Timer,
+    %% MS = ets:fun2ms(fun({Key, DeviceID, Time}) when Time < Now -> Key end),
+    MS = [{{{'$1', '$2'}, '$3', '$4'}, [{'<', '$4', Now}], [true]}],
+    _ = ets:select_delete(?OFFER_ETS, MS),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+-spec spawn_cleanup_offers(Timer :: non_neg_integer()) -> ok.
+spawn_cleanup_offers(Timer) ->
+    _ = erlang:spawn(fun() ->
+        ok = timer:sleep(Timer),
+        ok = cleanup_offers(Timer),
+        ok = spawn_cleanup_offers(Timer)
+    end),
+    ok.
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+ok_test() ->
+    ok = ?MODULE:init(),
+
+    Packet = blockchain_helium_packet_v1:new({eui, 16#deadbeef, 16#DEADC0DE}, <<"payload">>),
+    Hotspot = crypto:strong_rand_bytes(32),
+    Offer = blockchain_state_channel_offer_v1:from_packet(Packet, Hotspot, 'US915'),
+    Device = router_device:new(<<"device">>),
+
+    ok = ?MODULE:track_offer(Offer, Device),
+    ok = ?MODULE:track_packet(Packet, Hotspot, Device),
+
+    timer:sleep(10),
+
+    ?assertEqual([], ?MODULE:lookup_hotspot(Hotspot)),
+    ?assertEqual([], ?MODULE:lookup_device(router_device:id(Device))),
+
+    ets:delete(?ETS),
+    ets:delete(?OFFER_ETS),
+
+    ok.
+
+fail_test() ->
+    ok = ?MODULE:init(),
+
+    Packet = blockchain_helium_packet_v1:new({eui, 16#deadbeef, 16#DEADC0DE}, <<"payload">>),
+    Hotspot = crypto:strong_rand_bytes(32),
+    Offer = blockchain_state_channel_offer_v1:from_packet(Packet, Hotspot, 'US915'),
+    Device0 = router_device:new(<<"device0">>),
+
+    ok = ?MODULE:track_offer(Offer, Device0),
+
+    Device1 = router_device:new(<<"device1">>),
+    ok = ?MODULE:track_packet(Packet, Hotspot, Device1),
+
+    timer:sleep(10),
+
+    ?assertEqual(
+        [
+            {
+                router_device:id(Device1),
+                blockchain_utils:addr2name(Hotspot),
+                libp2p_crypto:bin_to_b58(Hotspot),
+                1
+            }
+        ],
+        ?MODULE:lookup_hotspot(Hotspot)
+    ),
+    ?assertEqual(
+        [
+            {
+                router_device:id(Device1),
+                blockchain_utils:addr2name(Hotspot),
+                libp2p_crypto:bin_to_b58(Hotspot),
+                1
+            }
+        ],
+        ?MODULE:lookup_device(router_device:id(Device1))
+    ),
+
+    ets:delete(?ETS),
+    ets:delete(?OFFER_ETS),
+
+    ok.
+
+cleanup_offers_test() ->
+    ok = ?MODULE:init(),
+
+    Packet = blockchain_helium_packet_v1:new({eui, 16#deadbeef, 16#DEADC0DE}, <<"payload">>),
+    Hotspot = crypto:strong_rand_bytes(32),
+    Offer = blockchain_state_channel_offer_v1:from_packet(Packet, Hotspot, 'US915'),
+    Device = router_device:new(<<"device">>),
+
+    ok = ?MODULE:track_offer(Offer, Device),
+
+    timer:sleep(110),
+
+    PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
+    ?assertMatch(1, erlang:length(ets:lookup(?OFFER_ETS, {Hotspot, PHash}))),
+
+    ok = cleanup_offers(100),
+
+    ?assertMatch(0, erlang:length(ets:lookup(?OFFER_ETS, {Hotspot, PHash}))),
+
+    ?assertEqual([], ?MODULE:lookup_hotspot(Hotspot)),
+    ?assertEqual([], ?MODULE:lookup_device(router_device:id(Device))),
+
+    ets:delete(?ETS),
+    ets:delete(?OFFER_ETS),
+
+    ok.
+
+-endif.

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -699,16 +699,8 @@ handle_cast(
                         false -> router_device:dev_nonces(Device0);
                         true -> [LastDevNonce | router_device:dev_nonces(Device0)]
                     end,
-                DevAddrs =
-                    case blockchain_helium_packet_v1:routing_info(Packet0) of
-                        {devaddr, DevAddr0} ->
-                            DevAddr1 = lorawan_utils:reverse(<<DevAddr0:32/integer-unsigned-big>>),
-                            [DevAddr1];
-                        _ ->
-                            %% This is mostly for lorawan SUITE as the C code does not provide routing_info
-                            %% as soon as testing is moved to lora lib we can remove and only pattern match to {devaddr, DevAddr0}
-                            router_device:devaddrs(Device0)
-                    end,
+                {devaddr, DevAddr0} = blockchain_helium_packet_v1:routing_info(Packet0),
+                DevAddr1 = lorawan_utils:reverse(<<DevAddr0:32/integer-unsigned-big>>),
                 DeviceUpdates = [
                     {keys,
                         lists:filter(
@@ -716,7 +708,7 @@ handle_cast(
                             router_device:keys(Device0)
                         )},
                     {dev_nonces, DevNonces},
-                    {devaddrs, DevAddrs}
+                    {devaddrs, [DevAddr1]}
                 ],
                 D1 = router_device:update(DeviceUpdates, Device0),
                 lager:debug(

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -699,8 +699,16 @@ handle_cast(
                         false -> router_device:dev_nonces(Device0);
                         true -> [LastDevNonce | router_device:dev_nonces(Device0)]
                     end,
-                {devaddr, DevAddr0} = blockchain_helium_packet_v1:routing_info(Packet0),
-                DevAddr1 = lorawan_utils:reverse(<<DevAddr0:32/integer-unsigned-big>>),
+                DevAddrs =
+                    case blockchain_helium_packet_v1:routing_info(Packet0) of
+                        {devaddr, DevAddr0} ->
+                            DevAddr1 = lorawan_utils:reverse(<<DevAddr0:32/integer-unsigned-big>>),
+                            [DevAddr1];
+                        _ ->
+                            %% This is mostly for lorawan SUITE as the C code does not provide routing_info
+                            %% as soon as testing is moved to lora lib we can remove and only pattern match to {devaddr, DevAddr0}
+                            router_device:devaddrs(Device0)
+                    end,
                 DeviceUpdates = [
                     {keys,
                         lists:filter(
@@ -708,7 +716,7 @@ handle_cast(
                             router_device:keys(Device0)
                         )},
                     {dev_nonces, DevNonces},
-                    {devaddrs, [DevAddr1]}
+                    {devaddrs, DevAddrs}
                 ],
                 D1 = router_device:update(DeviceUpdates, Device0),
                 lager:debug(

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -304,7 +304,7 @@ handle_call(
             {ok, DevAddr} = router_device_devaddr:allocate(Device0, PubKeyBin),
             DeviceUpdates = [
                 {keys, [{NwkSKey, AppSKey}]},
-                {devaddr, DevAddr},
+                {devaddrs, [DevAddr]},
                 {fcntdown, 0},
                 {channel_correction, false}
             ],
@@ -360,7 +360,7 @@ handle_cast(
             lager:info("device updated: ~p", [APIDevice]),
             router_device_channels_worker:refresh_channels(ChannelsWorker),
             IsActive = router_device:is_active(APIDevice),
-            Devaddr =
+            DevAddrs =
                 case
                     {
                         {router_device:app_eui(Device0), router_device:app_eui(APIDevice)},
@@ -368,17 +368,17 @@ handle_cast(
                     }
                 of
                     {{App, App}, {Dev, Dev}} ->
-                        router_device:devaddr(Device0);
+                        [router_device:devaddr(Device0)];
                     _ ->
                         lager:info("app_eui or dev_eui changed, unsetting devaddr"),
-                        undefined
+                        []
                 end,
 
             DeviceUpdates = [
                 {name, router_device:name(APIDevice)},
                 {dev_eui, router_device:dev_eui(APIDevice)},
                 {app_eui, router_device:app_eui(APIDevice)},
-                {devaddr, Devaddr},
+                {devaddrs, DevAddrs},
                 {metadata,
                     maps:merge(
                         lorawan_rxdelay:maybe_update(APIDevice, Device0),
@@ -699,17 +699,21 @@ handle_cast(
                         false -> router_device:dev_nonces(Device0);
                         true -> [LastDevNonce | router_device:dev_nonces(Device0)]
                     end,
+                {devaddr, DevAddr0} = blockchain_helium_packet_v1:routing_info(Packet0),
+                DevAddr1 = lorawan_utils:reverse(<<DevAddr0:32/integer-unsigned-big>>),
                 DeviceUpdates = [
                     {keys,
                         lists:filter(
                             fun({NwkSKey, _}) -> NwkSKey == UsedNwkSKey end,
                             router_device:keys(Device0)
                         )},
-                    {dev_nonces, DevNonces}
+                    {dev_nonces, DevNonces},
+                    {devaddrs, [DevAddr1]}
                 ],
-                lager:debug("we got our first uplink after join dev nonce=~p and key=~p", [
+                lager:debug("we got our first uplink after join dev nonce=~p key=~p, DevAddr=~p", [
                     LastDevNonce,
-                    UsedNwkSKey
+                    UsedNwkSKey,
+                    DevAddr1
                 ]),
                 router_device:update(DeviceUpdates, Device0)
         end,
@@ -1273,7 +1277,7 @@ handle_join(
         {dev_eui, DevEUI},
         {app_eui, AppEUI},
         {keys, [{NwkSKey, AppSKey} | router_device:keys(Device0)]},
-        {devaddr, DevAddr},
+        {devaddrs, [DevAddr | router_device:devaddrs(Device0)]},
         {fcntdown, 0},
         %% only do channel correction for 915 right now
         {channel_correction, Region /= 'US915'},

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -710,12 +710,15 @@ handle_cast(
                     {dev_nonces, DevNonces},
                     {devaddrs, [DevAddr1]}
                 ],
-                lager:debug("we got our first uplink after join dev nonce=~p key=~p, DevAddr=~p", [
-                    LastDevNonce,
-                    UsedNwkSKey,
-                    DevAddr1
-                ]),
-                router_device:update(DeviceUpdates, Device0)
+                D1 = router_device:update(DeviceUpdates, Device0),
+                lager:debug(
+                    "we got our first uplink after join dev nonces=~p keys=~p, DevAddrs=~p", [
+                        router_device:dev_nonces(D1),
+                        router_device:keys(D1),
+                        router_device:devaddrs(D1)
+                    ]
+                ),
+                D1
         end,
     case
         validate_frame(

--- a/src/metrics/router_metrics.erl
+++ b/src/metrics/router_metrics.erl
@@ -514,8 +514,9 @@ record_queues() ->
 -spec record_hotspot_reputations() -> ok.
 record_hotspot_reputations() ->
     lists:foreach(
-        fun({Hotspot, Counter}) ->
+        fun({Hotspot, PacketMissed, PacketUnknownDevice}) ->
             Name = blockchain_utils:addr2name(Hotspot),
+            Counter = PacketMissed + PacketUnknownDevice,
             case Counter >= router_hotspot_reputation:threshold() of
                 true ->
                     _ = prometheus_gauge:set(?METRICS_HOTSPOT_REPUTATION, [Name], Counter);

--- a/src/metrics/router_metrics.erl
+++ b/src/metrics/router_metrics.erl
@@ -263,7 +263,8 @@ handle_info(
             ok = record_ets(),
             ok = record_queues(),
             ok = record_grpc_connections(),
-            ok = record_hotspot_reputations()
+            ok = record_hotspot_reputations(),
+            ok = record_devices()
         end,
         [
             {fullsweep_after, 0},
@@ -526,6 +527,13 @@ record_hotspot_reputations() ->
         end,
         router_hotspot_reputation:reputations()
     ).
+
+-spec record_devices() -> ok.
+record_devices() ->
+    Running = proplists:get_value(active, supervisor:count_children(router_devices_sup), 0),
+    _ = prometheus_gauge:set(?METRICS_DEVICE_TOTAL, router_device_cache:size()),
+    _ = prometheus_gauge:set(?METRICS_DEVICE_RUNNING, Running),
+    ok.
 
 -spec get_pid_name(pid()) -> list().
 get_pid_name(Pid) ->

--- a/src/metrics/router_metrics_reporter.erl
+++ b/src/metrics/router_metrics_reporter.erl
@@ -195,21 +195,21 @@ export_devaddr_csv_test() ->
     DeviceUpdates0 = [
         {name, <<"Test Device Name 0">>},
         {location, PubKeyBin},
-        {devaddr, <<3, 4, 0, 72>>}
+        {devaddrs, [<<3, 4, 0, 72>>]}
     ],
     Device0 = router_device:update(DeviceUpdates0, router_device:new(<<"test_device_id_0">>)),
     {ok, _} = router_device:save(DB, CF, Device0),
     DeviceUpdates1 = [
         {name, <<"Test Device Name 1">>},
         {location, PubKeyBin},
-        {devaddr, <<3, 4, 0, 72>>}
+        {devaddrs, [<<3, 4, 0, 72>>]}
     ],
     Device1 = router_device:update(DeviceUpdates1, router_device:new(<<"test_device_id_1">>)),
     {ok, _} = router_device:save(DB, CF, Device1),
     DeviceUpdates2 = [
         {name, <<"Test Device Name 2">>},
         {location, PubKeyBin},
-        {devaddr, <<0, 4, 0, 72>>}
+        {devaddrs, [<<0, 4, 0, 72>>]}
     ],
     Device2 = router_device:update(DeviceUpdates2, router_device:new(<<"test_device_id_2">>)),
     {ok, _} = router_device:save(DB, CF, Device2),
@@ -267,7 +267,7 @@ export_devaddr_test() ->
     DeviceUpdates = [
         {name, <<"Test Device Name">>},
         {location, PubKeyBin},
-        {devaddr, <<3, 4, 0, 72>>}
+        {devaddrs, [<<3, 4, 0, 72>>]}
     ],
     Device = router_device:update(DeviceUpdates, router_device:new(<<"test_device_id">>)),
     {ok, _} = router_device:save(DB, CF, Device),

--- a/src/router_sup.erl
+++ b/src/router_sup.erl
@@ -67,6 +67,7 @@ init([]) ->
     BaseDir = application:get_env(blockchain, base_dir, "data"),
     ok = router_decoder:init_ets(),
     ok = router_hotspot_reputation:init(),
+    ok = router_device_stats:init(),
     ok = libp2p_crypto:set_network(application:get_env(blockchain, network, mainnet)),
 
     {ok, _} = application:ensure_all_started(ranch),

--- a/src/router_utils.erl
+++ b/src/router_utils.erl
@@ -882,13 +882,14 @@ trace_test() ->
     application:ensure_all_started(lager),
     application:set_env(lager, log_root, "log"),
     ets:new(router_device_cache_ets, [public, named_table, set]),
+    ets:new(router_device_cache_devaddr_ets, [public, named_table, bag]),
 
     DeviceID = <<"12345678910">>,
     Device = router_device:update(
         [
             {app_eui, <<"app_eui">>},
             {dev_eui, <<"dev_eui">>},
-            {devaddr, <<"devaddr">>}
+            {devaddrs, [<<"devaddr">>]}
         ],
         router_device:new(DeviceID)
     ),
@@ -902,6 +903,7 @@ trace_test() ->
     ?assert([] == get_device_traces(DeviceID)),
 
     ets:delete(router_device_cache_ets),
+    ets:delete(router_device_cache_devaddr_ets),
     application:stop(lager),
     ok.
 

--- a/test/router_lorawan_handler_test.erl
+++ b/test/router_lorawan_handler_test.erl
@@ -123,12 +123,14 @@ handle_info(
     #{<<"rxpk">> := [JSON]} = jsx:decode(JSONBin, [return_maps]),
     lager:info("got packet ~p", [JSON]),
     State#state.pid ! rx,
+    <<DevNum:32/integer-unsigned-little>> = <<33554431:25/integer-unsigned-little, $H:7/integer>>,
     HeliumPacket = #packet_pb{
         type = lorawan,
         payload = base64:decode(maps:get(<<"data">>, JSON)),
         signal_strength = maps:get(<<"rssi">>, JSON),
         frequency = maps:get(<<"freq">>, JSON),
-        datarate = maps:get(<<"datr">>, JSON)
+        datarate = maps:get(<<"datr">>, JSON),
+        routing = blockchain_helium_packet_v1:make_routing_info({devaddr, DevNum})
     },
     Packet = #blockchain_state_channel_packet_v1_pb{
         packet = HeliumPacket,

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -797,14 +797,8 @@ frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt) ->
 frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, Options) ->
     DevAddr = maps:get(devaddr, Options, <<33554431:25/integer-unsigned-little, $H:7/integer>>),
     Payload1 = frame_payload(MType, DevAddr, NwkSessionKey, AppSessionKey, FCnt, Options),
-    Routing =
-        case maps:get(routing, Options, false) of
-            true ->
-                <<DevNum:32/integer-unsigned-little>> = DevAddr,
-                blockchain_helium_packet_v1:make_routing_info({devaddr, DevNum});
-            false ->
-                undefined
-        end,
+    <<DevNum:32/integer-unsigned-little>> = DevAddr,
+    Routing = blockchain_helium_packet_v1:make_routing_info({devaddr, DevNum}),
     HeliumPacket = #packet_pb{
         type = lorawan,
         payload = Payload1,


### PR DESCRIPTION
This PR includes 

- Update reputation system to include `UnknownDevice` delivered packets.
- Make `devaddr` field a list (`devaddrs`) in `router_device` record so that Router can track  multiple devaddrs. until device actually send first `uplink` 