### PR TITLE
Use b58 strings in preferred hotspots

### DIFF
--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -1038,7 +1038,7 @@ json_device_to_record(JSONDevice, ADRDefault, US915CFListDefault, RxDelayDefault
         cf_list_enabled => kvc:path([<<"cf_list_enabled">>], JSONDevice, US915CFListDefault),
         rx_delay => kvc:path([<<"rx_delay">>], JSONDevice, RxDelayDefault),
         preferred_hotspots => [
-            lorawan_utils:hex_to_binary(P)
+            libp2p_crypto:b58_to_bin(P)
          || P <- kvc:path([<<"preferred_hotspots">>], JSONDevice)
         ]
     },

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -233,7 +233,7 @@ handle('GET', [<<"api">>, <<"router">>, <<"devices">>, DID], _Req, Args) ->
         <<"adr_allowed">> => ADRAllowed,
         <<"cf_list_enabled">> => US915JoinAcceptCFListEnabled,
         <<"rx_delay">> => RxDelay,
-        <<"preferred_hotspots">> => [lorawan_utils:binary_to_hex(P) || P <- PreferredHotspots]
+        <<"preferred_hotspots">> => [libp2p_crypto:bin_to_b58(P) || P <- PreferredHotspots]
     },
     case NotFound of
         true ->


### PR DESCRIPTION
This PR corrects a defect in the implementation of preferred hotspots:  the list of preferred hotspots received from Console is now decoded from b58 instead of hex.