### PR TITLE
Expect preferred hotspots as binary b58 strings

### DIFF
--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -1038,7 +1038,7 @@ json_device_to_record(JSONDevice, ADRDefault, US915CFListDefault, RxDelayDefault
         cf_list_enabled => kvc:path([<<"cf_list_enabled">>], JSONDevice, US915CFListDefault),
         rx_delay => kvc:path([<<"rx_delay">>], JSONDevice, RxDelayDefault),
         preferred_hotspots => [
-            libp2p_crypto:b58_to_bin(P)
+            hotspot_to_pubkey_bin(P)
          || P <- kvc:path([<<"preferred_hotspots">>], JSONDevice)
         ]
     },
@@ -1050,6 +1050,11 @@ json_device_to_record(JSONDevice, ADRDefault, US915CFListDefault, RxDelayDefault
         {is_active, kvc:path([<<"active">>], JSONDevice)}
     ],
     router_device:update(DeviceUpdates, router_device:new(ID)).
+
+-spec hotspot_to_pubkey_bin(B58Bin :: binary()) -> libp2p_crypto:pubkey_bin().
+hotspot_to_pubkey_bin(B58Bin) ->
+    B58Str = binary_to_list(B58Bin),
+    libp2p_crypto:b58_to_bin(B58Str).
 
 -spec downlink_token_lookup() -> {DownlinkEndpoint :: binary(), Token :: binary()}.
 downlink_token_lookup() ->

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -233,7 +233,10 @@ handle('GET', [<<"api">>, <<"router">>, <<"devices">>, DID], _Req, Args) ->
         <<"adr_allowed">> => ADRAllowed,
         <<"cf_list_enabled">> => US915JoinAcceptCFListEnabled,
         <<"rx_delay">> => RxDelay,
-        <<"preferred_hotspots">> => [libp2p_crypto:bin_to_b58(P) || P <- PreferredHotspots]
+        <<"preferred_hotspots">> => [
+            list_to_binary(libp2p_crypto:bin_to_b58(P))
+         || P <- PreferredHotspots
+        ]
     },
     case NotFound of
         true ->


### PR DESCRIPTION
This PR adds logic to `router_console_api` to decode preferred hotspots as a list of binaries containing b58 strings.