### PR TITLE
move ets init to supervisor

### DIFF
--- a/src/apis/router_console_dc_tracker.erl
+++ b/src/apis/router_console_dc_tracker.erl
@@ -11,6 +11,7 @@
 %% ------------------------------------------------------------------
 -export([
     start_link/1,
+    init_ets/0,
     refill/3,
     has_enough_dc/3,
     charge/3,
@@ -62,6 +63,11 @@
 
 start_link(Args) ->
     gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []).
+
+-spec init_ets() -> ok.
+init_ets() ->
+    ?ETS = ets:new(?ETS, [public, named_table, set]),
+    ok.
 
 -spec refill(OrgID :: binary(), Nonce :: non_neg_integer(), Balance :: non_neg_integer()) -> ok.
 refill(OrgID, Nonce, Balance) ->
@@ -148,7 +154,6 @@ current_balance(OrgID) ->
 %% ------------------------------------------------------------------
 init(Args) ->
     lager:info("~p init with ~p", [?SERVER, Args]),
-    ?ETS = ets:new(?ETS, [public, named_table, set]),
     ok = blockchain_event:add_handler(self()),
     {ok, PubKey, _, _} = blockchain_swarm:keys(),
     PubkeyBin = libp2p_crypto:pubkey_to_bin(PubKey),

--- a/src/apis/router_console_sup.erl
+++ b/src/apis/router_console_sup.erl
@@ -35,6 +35,7 @@ start_link() ->
 %% Supervisor callbacks
 %%====================================================================
 init([]) ->
+    ok = router_console_dc_tracker:init_ets(),
     DeviceAPIData = maps:from_list(application:get_env(router, router_console_api, [])),
     {ok,
         {?FLAGS, [

--- a/src/router_sup.erl
+++ b/src/router_sup.erl
@@ -66,6 +66,7 @@ start_link() ->
 init([]) ->
     BaseDir = application:get_env(blockchain, base_dir, "data"),
     ok = router_decoder:init_ets(),
+    ok = router_console_dc_tracker:init_ets(),
     ok = router_hotspot_reputation:init(),
     ok = router_device_stats:init(),
     ok = libp2p_crypto:set_network(application:get_env(blockchain, network, mainnet)),

--- a/src/router_sup.erl
+++ b/src/router_sup.erl
@@ -66,7 +66,6 @@ start_link() ->
 init([]) ->
     BaseDir = application:get_env(blockchain, base_dir, "data"),
     ok = router_decoder:init_ets(),
-    ok = router_console_dc_tracker:init_ets(),
     ok = router_hotspot_reputation:init(),
     ok = router_device_stats:init(),
     ok = libp2p_crypto:set_network(application:get_env(blockchain, network, mainnet)),


### PR DESCRIPTION
Something can take down the dc tracker table, and it will just stay down. preventing us from purchasing any packets.