### PR TITLE
update erlang-lorawan library

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -58,7 +58,7 @@
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},1},
  {<<"erlang_lorawan">>,
   {git,"https://github.com/helium/erlang-lorawan.git",
-       {ref,"14da4b271f76938373c1c1486d6c1a50844c3a1d"}},
+       {ref,"8685bc9149923f04d15505fe1637e5da616d5568"}},
   0},
  {<<"erlang_stats">>,
   {git,"https://github.com/helium/erlang-stats.git",


### PR DESCRIPTION
https://github.com/helium/erlang-lorawan/pull/8

The erlang-lorawan library causes issues with Downlinks.

One core issue: there was a typo in the list of DataRates. Somehow I missed adding the SF7BW500 datarate. That list determines the up to down datarate on the Downlink RX1 Window.

The added erlang-lorawan unit tests catch the issue. The tests call both the legacy API and the new library API and do a direct output comparison.