### PR TITLE
Erlang-LoRaWAN library improvements

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -58,7 +58,7 @@
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},1},
  {<<"erlang_lorawan">>,
   {git,"https://github.com/helium/erlang-lorawan.git",
-       {ref,"8685bc9149923f04d15505fe1637e5da616d5568"}},
+       {ref,"d26206dbf67a3b3ef65c54849dbe394bd2061c3a"}},
   0},
  {<<"erlang_stats">>,
   {git,"https://github.com/helium/erlang-stats.git",

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -177,7 +177,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 7,
+                <<"channel">> => 8,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             },

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -139,7 +139,7 @@ data_test_1(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 904.2999877929688,
+                <<"frequency">> => 923.2999877929688,
                 <<"channel">> => 8,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
@@ -176,7 +176,7 @@ data_test_1(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 904.2999877929688,
+                <<"frequency">> => 923.2999877929688,
                 <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
@@ -283,7 +283,7 @@ data_test_2(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 904.2999877929688,
+                <<"frequency">> => 923.2999877929688,
                 <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
@@ -426,7 +426,7 @@ data_test_3(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 904.2999877929688,
+                <<"frequency">> => 923.2999877929688,
                 <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -427,7 +427,7 @@ data_test_3(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 904.2999877929688,
-                <<"channel">> => 2,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -140,7 +140,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 904.2999877929688,
-                <<"channel">> => 2,
+                <<"channel">> => 8,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
@@ -177,7 +177,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 904.2999877929688,
-                <<"channel">> => 2,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             },
@@ -284,7 +284,7 @@ data_test_2(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 904.2999877929688,
-                <<"channel">> => 2,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -139,8 +139,8 @@ data_test_1(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 0,
+                <<"frequency">> => 904.2999877929688,
+                <<"channel">> => 2,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
@@ -176,8 +176,8 @@ data_test_1(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 0,
+                <<"frequency">> => 904.2999877929688,
+                <<"channel">> => 2,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             },
@@ -283,8 +283,8 @@ data_test_2(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 0,
+                <<"frequency">> => 904.2999877929688,
+                <<"channel">> => 2,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
@@ -426,8 +426,8 @@ data_test_3(Config) ->
                 <<"rssi">> => RSSI,
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
-                <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 0,
+                <<"frequency">> => 904.2999877929688,
+                <<"channel">> => 2,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }


### PR DESCRIPTION
Erlang-LoRaWAN library PR - https://github.com/helium/erlang-lorawan/pull/9

1. CN470 - Corrected channel listen frequencies.
2. Round to Nearest - Changed the frequency float rounding algorithm to a nearest match algorithm. CN470, EU433 and IN865 use multi decimal point frequencies which break a simple rounding function. An easier and elegant approach is to search the entire list of expected frequencies and find the closest match. This works generically for all plans. For example, 865.0625 is an IN865 Uplink channel. In this case 865.061 should adjust to 8065.0625 and not 865.1
3. Fat Channels - US915 and AU915 support fat Uplink channels which operate within a 250 or 500 kHz band. Added the fat channels to the Plan Uplink list. Most code should handle the higher data rate seamlessly.
4. Add unit tests to cover IN864, EU433 and KR920.
5. Create build_link_adr_req. This handles the "fat" channel and also handles the link_adr_req Downlink command in a simpler function and is also more generic.
6. Add Endianess parameter to the subnet library API. This allows either big or little endian DevAddr. By default LoRaWAN is little endian and that will be our default too.