### PR TITLE
Allow to change port for metrics scraper

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -64,3 +64,6 @@ ROUTER_HOTSPOT_REPUTATION_THRESHOLD=50
 #   - Resolution 3 or 4 is recommended as they will provide big enough hexagons to avoid conflicts.
 # See https://h3geo.org/docs/core-library/restable/ for resolution data
 ROUTER_DEVADDR_ALLOCATE_RESOLUTION=3
+
+# Set http port for Prometheus handler to come scrape metrics (Default to port 3000)
+ROUTER_METRICS_PORT=3000

--- a/config/sys.config
+++ b/config/sys.config
@@ -40,7 +40,8 @@
             {downlink_endpoint, <<"https://console.helium.com">>},
             {secret, <<>>}
         ]},
-        {device_queue_size_limit, 20}
+        {device_queue_size_limit, 20},
+        {metrics_port, 3000}
     ]},
     {grpcbox, [
         {servers, [

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -52,7 +52,8 @@
         {charge_when_no_offer, "${ROUTER_CHARGE_WHEN_NO_OFFER}"},
         {hotspot_reputation_enabled, "${ROUTER_HOTSPOT_REPUTATION_ENABLED}"},
         {hotspot_reputation_threshold, "${ROUTER_HOTSPOT_REPUTATION_THRESHOLD}"},
-        {devaddr_allocate_resolution, "${ROUTER_DEVADDR_ALLOCATE_RESOLUTION}"}
+        {devaddr_allocate_resolution, "${ROUTER_DEVADDR_ALLOCATE_RESOLUTION}"},
+        {metrics_port, "${ROUTER_METRICS_PORT}"}
     ]},
     {grpcbox, [
         {servers, [

--- a/config/test.config
+++ b/config/test.config
@@ -2,7 +2,7 @@
 [
     {router, [
         {oui, 1},
-        {metrics, [{port, 3001}]},
+        {metrics_port, 3001},
         {max_v8_context, 10},
         {router_http_channel_url_check, false},
         {router_xor_filter_worker, false},

--- a/src/metrics/router_metrics.erl
+++ b/src/metrics/router_metrics.erl
@@ -152,11 +152,10 @@ init(Args) ->
     erlang:process_flag(trap_exit, true),
     lager:info("~p init with ~p", [?SERVER, Args]),
     ok = declare_metrics(),
-    MetricsEnv = application:get_env(router, metrics, []),
     ElliOpts = [
         {callback, router_metrics_reporter},
         {callback_args, #{}},
-        {port, proplists:get_value(port, MetricsEnv, 3000)}
+        {port, router_utils:get_env_int(metrics_port, 3000)}
     ],
     {ok, _Pid} = elli:start_link(ElliOpts),
     ok = blockchain_event:add_handler(self()),


### PR DESCRIPTION
Fix for https://github.com/helium/router/issues/679