### PR TITLE
use build_link_addr_req

### DIFF
--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1861,10 +1861,10 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
             %% so we may need to do that there as well
             {true, false, _} ->
                 Plan = lora_plan:region_to_plan(Region),
-                lora_chmask:build_link_addr_req(Plan, {0, DataRateBinary}, []);
+                lora_chmask:build_link_adr_req(Plan, {0, DataRateBinary}, []);
             {false, _, {NewDataRateIdx, NewTxPowerIdx}} ->
                 Plan = lora_plan:region_to_plan(Region),
-                lora_chmask:build_link_addr_req(Plan, {NewTxPowerIdx, NewDataRateIdx}, []);
+                lora_chmask:build_link_adr_req(Plan, {NewTxPowerIdx, NewDataRateIdx}, []);
             _ ->
                 []
         end,

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1880,42 +1880,9 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
             %% Some regions allow the channel list to be sent in the join response as well,
             %% so we may need to do that there as well
             {true, false, _} ->
-                case Region of
-                    'US915' ->
-                        lora_chmask:make_link_adr_req(
-                            Region,
-                            {0, <<"NoChange">>, [Channels]},
-                            []
-                        );
-                    'AU915' ->
-                        lora_chmask:make_link_adr_req(
-                            Region,
-                            {0, <<"NoChange">>, [Channels]},
-                            []
-                        );
-                    _ ->
-                        lora_chmask:make_link_adr_req(
-                            Region,
-                            {0, DataRateBinary, [Channels]},
-                            []
-                        )
-                end;
+                lora_chmask:build_link_addr_req(Plan, {0, DataRateBinary}, []);
             {false, _, {NewDataRateIdx, NewTxPowerIdx}} ->
-                %% begin-needs-refactor
-                %%
-                %% This is silly because `NewDr' is converted right
-                %% back to the value `NewDataRateIdx' inside
-                %% `lorwan_mac_region'.  But `set_channels' wants data
-                %% rate in the form of "SFdd?BWddd?" so that's what
-                %% we'll give it.
-                Plan = lora_plan:region_to_plan(Region),
-                NewDr = lora_plan:datarate_to_binary(Plan, NewDataRateIdx),
-                %% end-needs-refactor
-                lora_chmask:make_link_adr_req(
-                    Region,
-                    {NewTxPowerIdx, NewDr, [Channels]},
-                    []
-                );
+                lora_chmask:build_link_addr_req(Plan, {NewTxPowerIdx, NewDataRateIdx}, []);
             _ ->
                 []
         end,

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1853,26 +1853,6 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
     DataRateBinary = erlang:list_to_binary(blockchain_helium_packet_v1:datarate(Packet)),
     ChannelCorrection = router_device:channel_correction(Device),
     ChannelCorrectionNeeded = ChannelCorrection == false,
-    %% begin-needs-refactor
-    %%
-    %% TODO: I don't know if we track these channel lists elsewhere,
-    %%       but since they were already hardcoded for 'US915' below,
-    %%       here's a few more.
-    Channels =
-        case Region of
-            'US915' ->
-                {8, 15};
-            'AU915' ->
-                {8, 15};
-            _ ->
-                AssumedChannels = {0, 7},
-                lager:warning("confirm channel plan for region ~p, assuming ~p", [
-                    Region,
-                    AssumedChannels
-                ]),
-                AssumedChannels
-        end,
-    %% end-needs-refactor
     FOpts1 =
         case {ChannelCorrectionNeeded, ChannelsCorrected, ADRAdjustment} of
             %% TODO this is going to be different for each region,
@@ -1880,8 +1860,10 @@ channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment
             %% Some regions allow the channel list to be sent in the join response as well,
             %% so we may need to do that there as well
             {true, false, _} ->
+                Plan = lora_plan:region_to_plan(Region),
                 lora_chmask:build_link_addr_req(Plan, {0, DataRateBinary}, []);
             {false, _, {NewDataRateIdx, NewTxPowerIdx}} ->
+                Plan = lora_plan:region_to_plan(Region),
                 lora_chmask:build_link_addr_req(Plan, {NewTxPowerIdx, NewDataRateIdx}, []);
             _ ->
                 []

--- a/src/lora/lorawan_mac_commands.erl
+++ b/src/lora/lorawan_mac_commands.erl
@@ -582,7 +582,7 @@ send_adr(
     (Failed == undefined orelse Failed == [])
 ->
     {TxIdx, DRIdx, _} = merge_adr(Node#node.adr_set, Node#node.adr_use),
-    lager:debug("LinkADRReq ~w", [{TxIdx, DrIdx}]),
+    lager:debug("LinkADRReq ~w", [{TxIdx, DRIdx}]),
     Plan = lora_plan:region_to_plan(Region),
     lora_chmask:build_link_addr_req(Plan, {TxIdx, DRIdx}, FOptsOut);
 send_adr(_Network, _Node, FOptsOut) ->

--- a/src/lora/lorawan_mac_commands.erl
+++ b/src/lora/lorawan_mac_commands.erl
@@ -584,7 +584,7 @@ send_adr(
     {TxIdx, DRIdx, _} = merge_adr(Node#node.adr_set, Node#node.adr_use),
     lager:debug("LinkADRReq ~w", [{TxIdx, DRIdx}]),
     Plan = lora_plan:region_to_plan(Region),
-    lora_chmask:build_link_addr_req(Plan, {TxIdx, DRIdx}, FOptsOut);
+    lora_chmask:build_link_adr_req(Plan, {TxIdx, DRIdx}, FOptsOut);
 send_adr(_Network, _Node, FOptsOut) ->
     % the device has disabled ADR
     FOptsOut.

--- a/src/lora/lorawan_mac_commands.erl
+++ b/src/lora/lorawan_mac_commands.erl
@@ -581,9 +581,9 @@ send_adr(
     (is_integer(TxPower) or is_integer(DataRate) or is_list(Chans)),
     (Failed == undefined orelse Failed == [])
 ->
-    Set = merge_adr(Node#node.adr_set, Node#node.adr_use),
+    {TxIdx, DRIdx, _} = merge_adr(Node#node.adr_set, Node#node.adr_use),
     lager:debug("LinkADRReq ~w", [Set]),
-    lora_chmask:make_link_adr_req(Region, Set, FOptsOut);
+    lora_chmask:build_link_addr_req(Plan, {TxIdx, DRIdx}, FOptsOut);
 send_adr(_Network, _Node, FOptsOut) ->
     % the device has disabled ADR
     FOptsOut.

--- a/src/lora/lorawan_mac_commands.erl
+++ b/src/lora/lorawan_mac_commands.erl
@@ -582,7 +582,8 @@ send_adr(
     (Failed == undefined orelse Failed == [])
 ->
     {TxIdx, DRIdx, _} = merge_adr(Node#node.adr_set, Node#node.adr_use),
-    lager:debug("LinkADRReq ~w", [Set]),
+    lager:debug("LinkADRReq ~w", [{TxIdx, DrIdx}]),
+    Plan = lora_plan:region_to_plan(Region),
     lora_chmask:build_link_addr_req(Plan, {TxIdx, DRIdx}, FOptsOut);
 send_adr(_Network, _Node, FOptsOut) ->
     % the device has disabled ADR

--- a/test/router_device_worker_SUITE.erl
+++ b/test/router_device_worker_SUITE.erl
@@ -287,17 +287,17 @@ device_worker_late_packet_double_charge_test(Config) ->
                     <<"channel_mask">> => 0,
                     <<"channel_mask_control">> => 7,
                     <<"command">> => <<"link_adr_req">>,
-                    <<"data_rate">> => 15,
+                    <<"data_rate">> => 2,
                     <<"number_of_transmissions">> => 0,
-                    <<"tx_power">> => 15
+                    <<"tx_power">> => 0
                 },
                 #{
                     <<"channel_mask">> => 65280,
                     <<"channel_mask_control">> => 0,
                     <<"command">> => <<"link_adr_req">>,
-                    <<"data_rate">> => 15,
+                    <<"data_rate">> => 2,
                     <<"number_of_transmissions">> => 0,
-                    <<"tx_power">> => 15
+                    <<"tx_power">> => 0
                 }
             ]
         }


### PR DESCRIPTION
Fixes https://github.com/helium/router/issues/724

Simpler implementation of make_link_adr_req which internally handles the Region logic.  One simplification is that all datarate formats are automatically handled.  Second, we determine the downlink datarate based on the incoming datarate which fixes the issue with #724

build_link_adr_req was created via this PR - https://github.com/helium/erlang-lorawan/pull/9