### PR TITLE
add support for gossipping a grpc address

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -26,7 +26,8 @@
         {sc_packet_handler, router_device_routing},
         {sc_max_actors, 1100},
         {sc_sup_type, server},
-        {sc_hook_close_submit, router_sc_worker}
+        {sc_hook_close_submit, router_sc_worker},
+        {metadata_fun, fun router_utils:metadata_fun/0}
     ]},
     {router, [
         {max_v8_context, 1000},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -32,6 +32,7 @@
         {sc_hook_close_submit, router_sc_worker}
     ]},
     {router, [
+        {grpc_port, ${GRPC_PORT:-8080}},
         {max_v8_context, 1000},
         {oui, "${ROUTER_OUI}"},
         {sc_open_dc_amount, "${ROUTER_SC_OPEN_DC_AMOUNT}"},

--- a/config/testnet.config.src
+++ b/config/testnet.config.src
@@ -33,6 +33,7 @@
         {sc_hook_close_submit, router_sc_worker}
     ]},
     {router, [
+        {grpc_port, ${GRPC_PORT:-8080}},
         {max_v8_context, 1000},
         {oui, "${ROUTER_OUI}"},
         {sc_open_dc_amount, "${ROUTER_SC_OPEN_DC_AMOUNT}"},


### PR DESCRIPTION
Related PR: https://github.com/helium/sibyl/pull/66

This adds support for routers to gossip their grpc address and fixes an issue whereby gateway-rs clients were being returned invalid grpc ports for router data from durable validators.  

With this fix, routers will gossip the grpc address ( including public ip and port ) to its peers.  Validators will then be able to derive this data from the peerbook and use it to return router routing addresses to clients.
