### PR TITLE
Send a properly formed downlink_ack event to Console

### DIFF
--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -271,7 +271,8 @@ event(Device, Map) ->
                             }
                         };
                     {downlink, SC} when
-                        SC == downlink_confirmed orelse SC == downlink_unconfirmed
+                        SC == downlink_confirmed orelse SC == downlink_unconfirmed orelse
+                            SC == downlink_ack
                     ->
                         #{
                             fcnt => maps:get(fcnt, Map),

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -100,7 +100,7 @@ mac_command_link_check_req_with_confirmed_up_test(Config) ->
     WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
     {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
 
-    %% Send UNCONFIRMED_UP frame packet
+    %% Send CONFIRMED_UP frame packet
     Stream !
         {send,
             test_utils:frame_packet(
@@ -158,7 +158,7 @@ mac_command_link_check_req_with_confirmed_up_test(Config) ->
                 <<"devaddr">> => fun erlang:is_binary/1,
                 <<"fcnt">> => 0,
                 <<"hotspot">> => fun erlang:is_map/1,
-                <<"integration">> => fun erlang:is_map/1,
+                %% <<"integration">> => fun erlang:is_map/1,
                 <<"mac">> =>
                     [
                         #{
@@ -2082,7 +2082,6 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             },
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),
@@ -2715,7 +2714,6 @@ adr_test(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             },
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -9,6 +9,7 @@
 -export([
     mac_commands_test/1,
     mac_command_link_check_req_test/1,
+    mac_command_link_check_req_with_confirmed_up_test/1,
     dupes_test/1,
     dupes2_test/1,
     join_test/1,
@@ -52,6 +53,7 @@ all() ->
     [
         mac_commands_test,
         mac_command_link_check_req_test,
+        mac_command_link_check_req_with_confirmed_up_test,
         dupes_test,
         join_test,
         us915_join_enabled_cf_list_test,
@@ -82,6 +84,116 @@ end_per_testcase(TestCase, Config) ->
 %%--------------------------------------------------------------------
 %% TEST CASES
 %%--------------------------------------------------------------------
+
+mac_command_link_check_req_with_confirmed_up_test(Config) ->
+    #{
+        pubkey_bin := PubKeyBin,
+        stream := Stream,
+        hotspot_name := HotspotName
+    } = test_utils:join_device(Config),
+
+    %% Waiting for reply from router to hotspot
+    test_utils:wait_state_channel_message(1250),
+
+    %% Check that device is in cache now
+    {ok, DB, CF} = router_db:get_devices(),
+    WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
+    {ok, Device0} = router_device:get_by_id(DB, CF, WorkerID),
+
+    %% Send UNCONFIRMED_UP frame packet
+    Stream !
+        {send,
+            test_utils:frame_packet(
+                ?CONFIRMED_UP,
+                PubKeyBin,
+                router_device:nwk_s_key(Device0),
+                router_device:app_s_key(Device0),
+                0,
+                #{
+                    fopts => [link_check_req]
+                }
+            )},
+
+    %% Waiting for report channel status from HTTP channel
+    {ok, _} = test_utils:wait_for_console_event(<<"uplink">>, #{
+        <<"id">> => fun erlang:is_binary/1,
+        <<"category">> => <<"uplink">>,
+        <<"sub_category">> => <<"uplink_confirmed">>,
+        <<"description">> => fun erlang:is_binary/1,
+        <<"reported_at">> => fun erlang:is_integer/1,
+        <<"device_id">> => ?CONSOLE_DEVICE_ID,
+        <<"data">> => #{
+            <<"dc">> => fun erlang:is_map/1,
+            <<"fcnt">> => 0,
+            <<"payload_size">> => fun erlang:is_integer/1,
+            <<"payload">> => fun erlang:is_binary/1,
+            <<"raw_packet">> => fun erlang:is_binary/1,
+            <<"port">> => fun erlang:is_integer/1,
+            <<"devaddr">> => fun erlang:is_binary/1,
+            <<"hotspot">> => #{
+                <<"id">> => erlang:list_to_binary(libp2p_crypto:bin_to_b58(PubKeyBin)),
+                <<"name">> => erlang:list_to_binary(HotspotName),
+                <<"rssi">> => 0.0,
+                <<"snr">> => 0.0,
+                <<"spreading">> => <<"SF8BW125">>,
+                <<"frequency">> => fun erlang:is_float/1,
+                <<"channel">> => fun erlang:is_number/1,
+                <<"lat">> => fun erlang:is_float/1,
+                <<"long">> => fun erlang:is_float/1
+            },
+            <<"mac">> => [#{<<"command">> => <<"link_check_req">>}],
+            <<"hold_time">> => fun erlang:is_integer/1
+        }
+    }),
+
+    {ok, _} = test_utils:wait_for_console_event(<<"downlink">>, #{
+        <<"id">> => fun erlang:is_binary/1,
+        <<"category">> => <<"downlink">>,
+        <<"sub_category">> => <<"downlink_ack">>,
+        <<"description">> => fun erlang:is_binary/1,
+        <<"device_id">> => ?CONSOLE_DEVICE_ID,
+        <<"reported_at">> => fun erlang:is_integer/1,
+        <<"data">> =>
+            #{
+                <<"devaddr">> => fun erlang:is_binary/1,
+                <<"fcnt">> => 0,
+                <<"hotspot">> => fun erlang:is_map/1,
+                <<"integration">> => fun erlang:is_map/1,
+                <<"mac">> =>
+                    [
+                        #{
+                            <<"command">> => <<"link_check_ans">>,
+                            <<"gateway_count">> => 1,
+                            <<"margin">> => 10
+                        },
+                        %% These come as part of the first downlink
+                        #{
+                            <<"channel_mask">> => fun erlang:is_integer/1,
+                            <<"channel_mask_control">> => fun erlang:is_integer/1,
+                            <<"command">> => <<"link_adr_req">>,
+                            <<"data_rate">> => fun erlang:is_integer/1,
+                            <<"number_of_transmissions">> => fun erlang:is_integer/1,
+                            <<"tx_power">> => fun erlang:is_integer/1
+                        },
+                        #{
+                            <<"channel_mask">> => fun erlang:is_integer/1,
+                            <<"channel_mask_control">> => fun erlang:is_integer/1,
+                            <<"command">> => <<"link_adr_req">>,
+                            <<"data_rate">> => fun erlang:is_integer/1,
+                            <<"number_of_transmissions">> => fun erlang:is_integer/1,
+                            <<"tx_power">> => fun erlang:is_integer/1
+                        }
+                    ],
+                <<"payload">> => fun erlang:is_binary/1,
+                <<"payload_size">> => fun erlang:is_integer/1,
+                <<"port">> => 0
+            }
+    }),
+
+    %% Ignore down messages updates
+    ok = test_utils:ignore_messages(),
+
+    ok.
 
 mac_command_link_check_req_test(Config) ->
     #{
@@ -1969,7 +2081,9 @@ adr_test(Config) ->
                 <<"channel">> => fun erlang:is_number/1,
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
-            }
+            },
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 
@@ -2600,7 +2714,9 @@ adr_test(Config) ->
                 <<"channel">> => fun erlang:is_number/1,
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
-            }
+            },
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -323,7 +323,6 @@ data_test_2(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             },
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),
@@ -468,7 +467,6 @@ data_test_3(Config) ->
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
             },
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -322,7 +322,9 @@ data_test_2(Config) ->
                 <<"channel">> => fun erlang:is_number/1,
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
-            }
+            },
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 
@@ -465,7 +467,9 @@ data_test_3(Config) ->
                 <<"channel">> => fun erlang:is_number/1,
                 <<"lat">> => fun erlang:is_float/1,
                 <<"long">> => fun erlang:is_float/1
-            }
+            },
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -665,7 +665,9 @@ uplink_confirmed_and_manually_downlink_test(Config) ->
             <<"payload">> => fun erlang:is_binary/1,
             <<"port">> => fun erlang:is_integer/1,
             <<"devaddr">> => fun erlang:is_binary/1,
-            <<"hotspot">> => fun erlang:is_map/1
+            <<"hotspot">> => fun erlang:is_map/1,
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 
@@ -726,7 +728,9 @@ uplink_confirmed_and_manually_downlink_test(Config) ->
             <<"payload">> => fun erlang:is_binary/1,
             <<"port">> => fun erlang:is_integer/1,
             <<"devaddr">> => fun erlang:is_binary/1,
-            <<"hotspot">> => fun erlang:is_map/1
+            <<"hotspot">> => fun erlang:is_map/1,
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 

--- a/test/router_downlink_SUITE.erl
+++ b/test/router_downlink_SUITE.erl
@@ -666,7 +666,6 @@ uplink_confirmed_and_manually_downlink_test(Config) ->
             <<"port">> => fun erlang:is_integer/1,
             <<"devaddr">> => fun erlang:is_binary/1,
             <<"hotspot">> => fun erlang:is_map/1,
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),
@@ -729,7 +728,6 @@ uplink_confirmed_and_manually_downlink_test(Config) ->
             <<"port">> => fun erlang:is_integer/1,
             <<"devaddr">> => fun erlang:is_binary/1,
             <<"hotspot">> => fun erlang:is_map/1,
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -630,7 +630,9 @@ lw_join_test(Config) ->
                 <<"channel">> => fun erlang:is_number/1,
                 <<"lat">> => '_',
                 <<"long">> => '_'
-            }
+            },
+            <<"integration">> => fun erlang:is_map/1,
+            <<"mac">> => fun erlang:is_list/1
         }
     }),
 

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -631,7 +631,6 @@ lw_join_test(Config) ->
                 <<"lat">> => '_',
                 <<"long">> => '_'
             },
-            <<"integration">> => fun erlang:is_map/1,
             <<"mac">> => fun erlang:is_list/1
         }
     }),


### PR DESCRIPTION
This PR addresses issue #757.  It corrects a bug where Router sent an incorrectly formatted event message to Console when the subcategory was `downlink_ack`. Specifically, the `integration` and `mac` keys were omitted.