### PR TITLE
update library and add lager debug

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -58,7 +58,7 @@
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},1},
  {<<"erlang_lorawan">>,
   {git,"https://github.com/helium/erlang-lorawan.git",
-       {ref,"49925a083347e91e74daee3516a2105e82ef6c07"}},
+       {ref,"eb4c1cfb35c610a2c2d296dbe9dd01be0c021cc6"}},
   0},
  {<<"erlang_stats">>,
   {git,"https://github.com/helium/erlang-stats.git",

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1364,13 +1364,12 @@ dualplan_region(Packet, HotspotRegion) ->
     DataRate = erlang:list_to_binary(
         blockchain_helium_packet_v1:datarate(Packet)
     ),
-    DataRateAtom = lora_plan:datarate_to_atom(DataRate),
     DeviceRegion = lora_plan:dualplan_region(HotspotRegion, Frequency, DataRate),
     lager:debug(
         "Join Frequency ~p DataRate ~p HotspotRegion ~p DeviceRegion ~p",
         [
             Frequency,
-            DataRateAtom,
+            DataRate,
             HotspotRegion,
             DeviceRegion
         ]

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1335,7 +1335,7 @@ handle_join(
     ],
     Device1 = router_device:update(DeviceUpdates, Device0),
     lager:debug(
-        "DevEUI ~s with AppEUI ~s tried to join with nonce ~p region ~p via ~s",
+        "Join DevEUI ~s with AppEUI ~s tried to join with nonce ~p region ~p via ~s",
         [
             lorawan_utils:binary_to_hex(DevEUI),
             lorawan_utils:binary_to_hex(AppEUI),
@@ -1364,7 +1364,17 @@ dualplan_region(Packet, HotspotRegion) ->
     DataRate = erlang:list_to_binary(
         blockchain_helium_packet_v1:datarate(Packet)
     ),
+    DataRateAtom = lora_plan:datarate_to_atom(DataRate),
     DeviceRegion = lora_plan:dualplan_region(HotspotRegion, Frequency, DataRate),
+    lager:debug(
+        "Join Frequency ~p DataRate ~p HotspotRegion ~p DeviceRegion ~p",
+        [
+            Frequency,
+            DataRateAtom,
+            HotspotRegion,
+            DeviceRegion
+        ]
+    ),
     DeviceRegion.
 
 -spec region_or_default(


### PR DESCRIPTION
Add lager debug to better log and understand why AU915 sub-bank 5 connections fall through with AS923-1 hotspots.