### PR TITLE
dual plan region fix

### DIFF
--- a/src/device/router_device.erl
+++ b/src/device/router_device.erl
@@ -499,7 +499,7 @@ can_queue_payload(Payload, DownlinkRegion, Device) ->
         true ->
             {error, queue_size_limit};
         false ->
-            Region = router_utils:either(DownlinkRegion, ?MODULE:region(Device)),
+            Region = router_utils:either(?MODULE:region(Device), DownlinkRegion),
             UpDRIndex = ?MODULE:last_known_datarate(Device),
             Plan = lora_plan:region_to_plan(Region),
             DownDRIndex = lora_plan:up_to_down_datarate(Plan, UpDRIndex, 0),

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -1037,7 +1037,7 @@ send_to_device_worker(
                 [
                     DevAddr,
                     lorawan_utils:binary_to_hex(DevAddr),
-                    libp2p_crypto:bin_to_b58(PubKeyBin)
+                    blockchain_utils:addr2name(PubKeyBin)
                 ]
             ),
             {error, unknown_device};

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1733,9 +1733,9 @@ handle_frame_timeout(
     []
 ) ->
     ACK = router_utils:mtype_to_ack(Frame#frame.mtype),
+    Region = router_device:region(Device0),
     WereChannelsCorrected = were_channels_corrected(Frame, Region),
     ChannelCorrection = router_device:channel_correction(Device0),
-    Region = router_device:region(Device0),
     {ChannelsCorrected, FOpts1} = channel_correction_and_fopts(
         Packet0,
         Region,
@@ -1830,8 +1830,8 @@ handle_frame_timeout(
 ) ->
     ACK = router_utils:mtype_to_ack(Frame#frame.mtype),
     MType = ack_to_mtype(ConfirmedDown),
-    WereChannelsCorrected = were_channels_corrected(Frame, Region),
     Region = router_device:region(Device0),
+    WereChannelsCorrected = were_channels_corrected(Frame, Region),
     {ChannelsCorrected, FOpts1} = channel_correction_and_fopts(
         Packet0,
         Region,

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -1712,7 +1712,7 @@ charge_when_no_offer() ->
 %%%-------------------------------------------------------------------
 -spec handle_frame_timeout(
     Packet0 :: blockchain_helium_packet_v1:packet(),
-    Region :: atom(),
+    HotspotRegion :: atom(),
     Device0 :: router_device:device(),
     Frame :: #frame{},
     Count :: pos_integer(),
@@ -1725,7 +1725,7 @@ charge_when_no_offer() ->
 
 handle_frame_timeout(
     Packet0,
-    Region,
+    _HotspotRegion,
     Device0,
     Frame,
     Count,
@@ -1735,6 +1735,7 @@ handle_frame_timeout(
     ACK = router_utils:mtype_to_ack(Frame#frame.mtype),
     WereChannelsCorrected = were_channels_corrected(Frame, Region),
     ChannelCorrection = router_device:channel_correction(Device0),
+    Region = router_device:region(Device0),
     {ChannelsCorrected, FOpts1} = channel_correction_and_fopts(
         Packet0,
         Region,
@@ -1817,7 +1818,7 @@ handle_frame_timeout(
     end;
 handle_frame_timeout(
     Packet0,
-    Region,
+    _HotspotRegion,
     Device0,
     Frame,
     Count,
@@ -1830,6 +1831,7 @@ handle_frame_timeout(
     ACK = router_utils:mtype_to_ack(Frame#frame.mtype),
     MType = ack_to_mtype(ConfirmedDown),
     WereChannelsCorrected = were_channels_corrected(Frame, Region),
+    Region = router_device:region(Device0),
     {ChannelsCorrected, FOpts1} = channel_correction_and_fopts(
         Packet0,
         Region,
@@ -1947,7 +1949,8 @@ handle_frame_timeout(
     pos_integer(),
     lora_adr:adjustment()
 ) -> {boolean(), list()}.
-channel_correction_and_fopts(Packet, Region, Device, Frame, Count, ADRAdjustment) ->
+channel_correction_and_fopts(Packet, _HotspotRegion, Device, Frame, Count, ADRAdjustment) ->
+    Region = router_device:region(Device),
     Plan = lora_plan:region_to_plan(Region),
     ChannelsCorrected = were_channels_corrected(Frame, Region),
     DataRateBinary = erlang:list_to_binary(blockchain_helium_packet_v1:datarate(Packet)),
@@ -2190,12 +2193,13 @@ maybe_track_adr_offer(Device, ADREngine0, Offer) ->
 ) -> {undefined | lora_adr:handle(), lora_adr:adjustment()}.
 maybe_track_adr_packet(Device, ADREngine0, FrameCache) ->
     Metadata = router_device:metadata(Device),
+    Region = router_device:region(Device),
     #frame_cache{
         rssi = RSSI,
         packet = Packet,
         pubkey_bin = PubKeyBin,
         frame = Frame,
-        region = Region
+        region = _HotspotRegion
     } = FrameCache,
     #frame{fopts = FOpts, adr = ADRBit, adrackreq = ADRAckReqBit} = Frame,
     ADRAllowed = maps:get(adr_allowed, Metadata, false),

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -986,7 +986,8 @@ handle_info(
             device = Device0,
             pid = Pid
         } = maps:get(DevNonce, JoinCache),
-    {Packet, PubKeyBin, Region, _PacketTime, _HoldTime} = PacketSelected,
+    {Region, _N, _D, _K} = JoinAcceptArgs,
+    {Packet, PubKeyBin, _HotspotRegion, _PacketTime, _HoldTime} = PacketSelected,
     lager:debug("join timeout for ~p / selected ~p out of ~p", [
         DevNonce,
         lager:pr(Packet, blockchain_helium_packet_v1),

--- a/src/device/router_device_worker.erl
+++ b/src/device/router_device_worker.erl
@@ -986,8 +986,12 @@ handle_info(
             device = Device0,
             pid = Pid
         } = maps:get(DevNonce, JoinCache),
-    {Region, _N, _D, _K} = JoinAcceptArgs,
-    {Packet, PubKeyBin, _HotspotRegion, _PacketTime, _HoldTime} = PacketSelected,
+    #join_accept_args{
+        region = Region,
+        app_nonce = _N,
+        dev_addr = _D,
+        app_key = _K} = JoinAcceptArgs,
+    {Packet, PubKeyBin, _Region, _PacketTime, _HoldTime} = PacketSelected,
     lager:debug("join timeout for ~p / selected ~p out of ~p", [
         DevNonce,
         lager:pr(Packet, blockchain_helium_packet_v1),

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -198,7 +198,7 @@ data_test_2(Config) ->
         pubkey_bin := PubKeyBin,
         stream := Stream,
         hotspot_name := HotspotName
-    } = test_utils:join_device(Config),
+    } = test_utils:join_device(Config, #{region => 'EU868'}),
 
     %% Waiting for reply from router to hotspot
     test_utils:wait_state_channel_message(1250),
@@ -342,7 +342,7 @@ data_test_3(Config) ->
         pubkey_bin := PubKeyBin,
         stream := Stream,
         hotspot_name := HotspotName
-    } = test_utils:join_device(Config),
+    } = test_utils:join_device(Config, #{region => 'EU868'}),
 
     %% Waiting for reply from router to hotspot
     test_utils:wait_state_channel_message(1250),


### PR DESCRIPTION
DualPlan is a feature we wish to deploy ASAP.  It allows both AS923-1 and AU915 end-devices to Join the same Gateway.  This is achieved with the DualPlan feature code which was already implemented.  During AU915 testing some issues were discovered.

Currently the Join Response frequency mirrors the Join Uplink frequency.  This indicates we are still using the Hotspot Region rather than the DeviceRegion to determine the Downlink channel.

Discovered the issue during debugging on Dev.  We cache the device Region during the Join.  This device cache was not always being used, rather the HotspotRegion was used instead.  The solution is to handle any cases where the device Region should be used, rather than the HotspotRegion.

Solution tested on Dev with an AS923-1 Hotspot while connecting with an AU915 end-device.  The AU915 end-device was programmed to use sub-bank six.