### PR TITLE
More responses to grpc endpoints

### DIFF
--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -253,7 +253,7 @@ handle_free_packet(SCPacket, PacketTime, Pid) when is_pid(Pid) ->
             %% This is redondant but at least we dont have to redo all that code...
             case packet(Packet, PacketTime, HoldTime, PubKeyBin, Region, Pid, Chain) of
                 {error, Reason} = Err ->
-                    Pid ! Err,
+                    Pid ! {error, reason_to_single_atom(Reason)},
                     lager:debug("packet from ~p discarded ~p", [HotspotName, Reason]),
                     ok = handle_packet_metrics(Packet, reason_to_single_atom(Reason), Start),
                     Err;
@@ -268,7 +268,7 @@ handle_free_packet(SCPacket, PacketTime, Pid) when is_pid(Pid) ->
             end;
         {error, Reason} = Err ->
             lager:debug("packet from ~p discarded ~p", [HotspotName, Reason]),
-            Pid ! Err,
+            Pid ! {error, reason_to_single_atom(Reason)},
             Err
     end.
 

--- a/src/grpc/helium_router_service.erl
+++ b/src/grpc/helium_router_service.erl
@@ -46,10 +46,10 @@ wait_for_response(Ctx) ->
         {packet, Packet} ->
             lager:debug("received packet ~p", [Packet]),
             {ok, #blockchain_state_channel_message_v1_pb{msg = {packet, Packet}}, Ctx};
-        {error, _Reason} ->
-            lager:debug("received error msg ~p", [_Reason]),
-            {grpc_error, {grpcbox_stream:code_to_status(2), <<"no response">>}}
+        {error, Reason} ->
+            lager:debug("received error msg ~p", [Reason]),
+            {grpc_error, {grpcbox_stream:code_to_status(2), erlang:atom_to_binary(Reason)}}
     after ?TIMEOUT ->
         lager:debug("failed to receive response msg after ~p seconds", [?TIMEOUT]),
-        {grpc_error, {grpcbox_stream:code_to_status(2), <<"no response">>}}
+        {grpc_error, {grpcbox_stream:code_to_status(2), <<"timeout no response">>}}
     end.

--- a/test/router_grpc_SUITE.erl
+++ b/test/router_grpc_SUITE.erl
@@ -8,11 +8,14 @@
 
 -export([
     join_grpc_test/1,
-    join_from_unknown_device_grpc_test/1
+    join_from_unknown_device_grpc_test/1,
+    packet_from_known_device_no_downlink/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("lorawan_vars.hrl").
+-include("console_test.hrl").
 
 %%--------------------------------------------------------------------
 %% COMMON TEST CALLBACK FUNCTIONS
@@ -27,7 +30,8 @@
 all() ->
     [
         join_grpc_test,
-        join_from_unknown_device_grpc_test
+        join_from_unknown_device_grpc_test,
+        packet_from_known_device_no_downlink
     ].
 
 %%--------------------------------------------------------------------
@@ -86,7 +90,62 @@ join_from_unknown_device_grpc_test(_Config) ->
     ct:pal("Response Body: ~p", [ResponseMsg]),
     #{<<":status">> := HttpStatus} = Headers,
     ?assertEqual(HttpStatus, <<"200">>),
-    ?assertEqual(ResponseMsg, <<"no response">>),
+    ?assertEqual(ResponseMsg, <<"not_found">>),
+
+    ok.
+
+packet_from_known_device_no_downlink(Config) ->
+    AppKey = proplists:get_value(app_key, Config),
+    {ok, PubKey, SigFun, _} = blockchain_swarm:keys(),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    %% create a join packet
+    JoinNonce = crypto:strong_rand_bytes(2),
+
+    {ok, #{msg := {response, ResponseMsg}}, #{headers := Headers, trailers := _Trailers}} = helium_router_client:route(
+        join_packet_map(PubKeyBin, SigFun, AppKey, JoinNonce, -40)
+    ),
+    #{<<":status">> := HttpStatus} = Headers,
+    ?assertEqual(HttpStatus, <<"200">>),
+    ?assertEqual(ResponseMsg, ResponseMsg#{accepted := true}),
+
+    %% We are joined
+    {ok, DB, CF} = router_db:get_devices(),
+    WorkerID = router_devices_sup:id(?CONSOLE_DEVICE_ID),
+    {ok, Device} = router_device:get_by_id(DB, CF, WorkerID),
+
+    %% Send first packet to get CFList response
+    timer:sleep(router_utils:frame_timeout()),
+    {ok, #{msg := {response, Resp0}}, #{headers := Headers1}} = helium_router_client:route(
+        data_packet_map(
+            ?UNCONFIRMED_UP,
+            1,
+            PubKeyBin,
+            Device,
+            SigFun,
+            #{}
+        )
+    ),
+
+    #{<<":status">> := HttpStatus1} = Headers1,
+    ?assertEqual(HttpStatus1, <<"200">>),
+    ?assertEqual(Resp0, Resp0#{accepted := true}),
+
+    %% Send another uplink now that we have our cflist, confirming the change, we expect no downlink
+    timer:sleep(router_utils:frame_timeout()),
+    {ok, #{msg := {response, Resp1}}, #{}} = helium_router_client:route(
+        data_packet_map(
+            ?UNCONFIRMED_UP,
+            2,
+            PubKeyBin,
+            Device,
+            SigFun,
+            #{fopts => [{link_adr_ans, 1, 1, 1}]}
+        )
+    ),
+
+    ?assertEqual(Resp1, Resp1#{accepted := true}),
+    ?assertNot(maps:is_key(downlink, Resp1)),
 
     ok.
 
@@ -117,6 +176,35 @@ join_packet_map(PubKeyBin, SigFun, AppKey, DevNonce, RSSI) ->
     Signature = signature(SCPacketMap0, SigFun),
     PacketMap1 = maps:put(signature, Signature, SCPacketMap0),
     #{msg => {packet, PacketMap1}}.
+
+data_packet_map(MType, Fcnt, PubKeyBin, Device, SigFun, Options) ->
+    DevAddr0 = <<33554431:25/integer-unsigned-little, $H:7/integer>>,
+    <<DevAddr:32/integer-unsigned-little>> = DevAddr0,
+    PMap = #{
+        oui => 0,
+        type => lorawan,
+        timestamp => 1000,
+        signal_strength => -40,
+        frequency => 923.3,
+        datarate => <<"SF8BW125">>,
+        snr => 0.0,
+        routing => #{data => {devaddr, DevAddr}},
+        rx2_window => undefined,
+        %%
+        payload => test_utils:frame_payload(
+            MType,
+            DevAddr0,
+            router_device:nwk_s_key(Device),
+            router_device:app_s_key(Device),
+            Fcnt,
+            Options
+        )
+    },
+    SCPMap = #{packet => PMap, hotspot => PubKeyBin, region => 'US915', hold_time => 100},
+    Signature = signature(SCPMap, SigFun),
+    PacketMap = maps:put(signature, Signature, SCPMap),
+
+    #{msg => {packet, PacketMap}}.
 
 signature(SCPacketMap, SigFun) ->
     #{


### PR DESCRIPTION
- send back the error atom when not handling an packet
- explicitly call out timeouts

NOTE: We respond to packets that don't require a downlink with
`#{accepted => true}` after the frame timeout has elapsed.