### PR TITLE
update proto ref

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
     {inet_cidr, "1.1.0", {pkg, erl_cidr}},
     {throttle, "0.3.0", {pkg, lambda_throttle}},
     {e2qc, {git, "https://github.com/helium/e2qc.git", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "dpezely/packet_router"}}}
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}}
 ]}.
 
 {plugins, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -103,7 +103,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.1">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"25fc8c711857e9dc2be59fa6d7f7019f796fa4f8"}},
+       {ref,"1a1a4ae82a898620d96cb486ed76d3857d3ed8f2"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"httpc_aws">>,


### PR DESCRIPTION
Sync with proto PR.  Fixes compile issue because 25fc8c no longer exists.
https://github.com/helium/proto/pull/193