### PR TITLE
Erlang_lorawan library reference update

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -62,7 +62,7 @@
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},1},
  {<<"erlang_lorawan">>,
   {git,"https://github.com/helium/erlang-lorawan.git",
-       {ref,"29704ae1b29386993bfcf69d1ae4fc04d8502f0e"}},
+       {ref,"248b59e827872fe3c2c2536fcaf9e1ab6803a084"}},
   0},
  {<<"erlang_stats">>,
   {git,"https://github.com/helium/erlang-stats.git",

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -140,7 +140,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 8,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
@@ -177,7 +177,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 7,
+                <<"channel">> => 8,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             },

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -177,7 +177,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 8,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             },


### PR DESCRIPTION
Update to latest Erlang_lorawan library.  The library updates an incorrect US915 fat channel.
Note - this change caused a CT test failure because 923.3 pattern matched against the topmost channel, which was 8.  But with the channel frequency correction it will now correctly pattern match against the new topmost channel, which is now 7.