### PR TITLE
update lorawan library

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -62,7 +62,7 @@
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},1},
  {<<"erlang_lorawan">>,
   {git,"https://github.com/helium/erlang-lorawan.git",
-       {ref,"29704ae1b29386993bfcf69d1ae4fc04d8502f0e"}},
+       {ref,"8d7426756110dcbc0fe2aa9802f4b05740d77df4"}},
   0},
  {<<"erlang_stats">>,
   {git,"https://github.com/helium/erlang-stats.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -62,7 +62,7 @@
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},1},
  {<<"erlang_lorawan">>,
   {git,"https://github.com/helium/erlang-lorawan.git",
-       {ref,"8d7426756110dcbc0fe2aa9802f4b05740d77df4"}},
+       {ref,"fc490362eb52e00466dd8655ed27eb4dff07308a"}},
   0},
  {<<"erlang_stats">>,
   {git,"https://github.com/helium/erlang-stats.git",

--- a/test/router_data_SUITE.erl
+++ b/test/router_data_SUITE.erl
@@ -140,7 +140,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 8,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             }
@@ -177,7 +177,7 @@ data_test_1(Config) ->
                 <<"snr">> => SNR,
                 <<"spreading">> => DataRate,
                 <<"frequency">> => 923.2999877929688,
-                <<"channel">> => 8,
+                <<"channel">> => 7,
                 <<"lat">> => 36.999918858583605,
                 <<"long">> => fun check_long/1
             },


### PR DESCRIPTION
The chmask code in the LoRaWAN library requires knowledge of the specific region, e.g. AS923_1B or AU915_SB5.  Without knowing the specific Region names, the library has default behavior.

This update is intended to fix issues found by sensor users in Malaysia and Australia.