### PR TITLE
fetch assignable devaddr range from config service

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -53,7 +53,8 @@
             port => "${ROUTER_ICS_PORT}",
             eui_enabled => "${ROUTER_ICS_EUI_ENABLED}",
             skf_enabled => "${ROUTER_ICS_SKF_ENABLED}",
-            devaddr_enabled => "${ROUTER_ICS_DEVADDR_ENABLED}"
+            devaddr_enabled => "${ROUTER_ICS_DEVADDR_ENABLED}",
+            route_id => "${ROUTER_ICS_ROUTE_ID}"
         }},
         {frame_timeout, "${ROUTER_FRAME_TIMEOUT}"},
         {disco_frame_timeout, "${ROUTER_DISCO_FRAME_TIMEOUT}"},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -52,7 +52,8 @@
             host => "${ROUTER_ICS_HOST}",
             port => "${ROUTER_ICS_PORT}",
             eui_enabled => "${ROUTER_ICS_EUI_ENABLED}",
-            skf_enabled => "${ROUTER_ICS_SKF_ENABLED}"
+            skf_enabled => "${ROUTER_ICS_SKF_ENABLED}",
+            devaddr_enabled => "${ROUTER_ICS_DEVADDR_ENABLED}"
         }},
         {frame_timeout, "${ROUTER_FRAME_TIMEOUT}"},
         {disco_frame_timeout, "${ROUTER_DISCO_FRAME_TIMEOUT}"},

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -118,6 +118,9 @@ init(Args) ->
         end,
     {ok, #state{oui = OUI}}.
 
+handle_call({set_devaddr_bases, []}, _From, State) ->
+    lager:info("trying to set empty devaddr bases, ignoring"),
+    {reply, ok, State};
 handle_call({set_devaddr_bases, Ranges}, _From, State) ->
     NewState = State#state{devaddr_bases = lists:usort(Ranges), keys = #{}},
     {reply, ok, NewState};
@@ -148,7 +151,7 @@ handle_cast(_Msg, State) ->
     lager:warning("rcvd unknown cast msg: ~p", [_Msg]),
     {noreply, State}.
 
-handle_info(post_init_chain, #state{oui = OUI} = State0) ->
+handle_info(post_init_chain, #state{oui = OUI, devaddr_bases = []} = State0) ->
     Subnets = router_blockchain:subnets_for_oui(OUI),
     Ranges = expand_ranges(subnets_to_ranges(Subnets)),
     {noreply, State0#state{devaddr_bases = Ranges}};

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -341,12 +341,22 @@ to_res_test() ->
     ok.
 
 set_range_allocation_test_() ->
-    [
-        ?_test(test_no_subnet()),
-        ?_test(test_subnet_wrap()),
-        ?_test(test_non_sequential_subnet()),
-        ?_test(test_replace_range())
-    ].
+    {
+        foreach,
+        fun() ->
+            meck:new(router_blockchain),
+            meck:expect(router_blockchain, get_hotspot_location_index, fun(_) ->
+                {error, use_default_index}
+            end)
+        end,
+        fun(_) -> meck:unload() end,
+        [
+            ?_test(test_no_subnet()),
+            ?_test(test_subnet_wrap()),
+            ?_test(test_non_sequential_subnet()),
+            ?_test(test_replace_range())
+        ]
+    }.
 
 test_no_subnet() ->
     #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -69,7 +69,8 @@ set_devaddr_bases(Ranges) ->
 get_devaddr_bases() ->
     gen_server:call(?MODULE, get_devaddr_bases).
 
--spec sort_devices([router_device:device()], libp2p_crypto:pubkey_bin()) -> [router_device:device()].
+-spec sort_devices([router_device:device()], libp2p_crypto:pubkey_bin()) ->
+    [router_device:device()].
 sort_devices(Devices, PubKeyBin) ->
     case ?MODULE:pubkeybin_to_loc(PubKeyBin) of
         {error, _Reason} ->
@@ -121,7 +122,7 @@ handle_call({allocate, _Device, _PubKeyBin}, _From, #state{devaddr_bases = []} =
 handle_call(
     {allocate, _Device, PubKeyBin},
     _From,
-    #state{ devaddr_bases = Numbers, keys = Keys} = State
+    #state{devaddr_bases = Numbers, keys = Keys} = State
 ) ->
     Parent = ?MODULE:h3_parent_for_pubkeybin(PubKeyBin),
 
@@ -195,19 +196,11 @@ subnets_to_ranges(Subnets) ->
     ).
 
 -spec expand_ranges(list({Min, Max})) -> [non_neg_integer()] when
-    Min :: non_neg_integer() | binary(),
-    Max :: non_neg_integer() | binary().
+    Min :: non_neg_integer(),
+    Max :: non_neg_integer().
 expand_ranges(Ranges) ->
     lists:flatmap(
-        fun
-            ({Start, End}) when erlang:is_number(Start) ->
-                lists:seq(Start, End);
-            ({StartHex, EndHex}) ->
-                lists:seq(
-                    erlang:binary_to_integer(StartHex, 16),
-                    erlang:binary_to_integer(EndHex, 16)
-                )
-        end,
+        fun({Start, End}) -> lists:seq(Start, End) end,
         Ranges
     ).
 
@@ -346,7 +339,6 @@ set_range_allocation_test_() ->
     [
         ?_test(test_no_subnet()),
         ?_test(test_subnet_wrap()),
-        %% ?_test(test_multiple_keys()),
         ?_test(test_non_sequential_subnet()),
         ?_test(test_replace_range())
     ].

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -22,9 +22,10 @@
 -export([
     start_link/1,
     allocate/2,
+    set_devaddr_bases/1,
     sort_devices/2,
     pubkeybin_to_loc/1,
-    net_id/1
+    h3_parent_for_pubkeybin/1
 ]).
 
 %% ------------------------------------------------------------------
@@ -40,14 +41,11 @@
 ]).
 
 -define(SERVER, ?MODULE).
--define(ETS, router_device_devaddr_ets).
-%%
--define(BITS_23, 8388607).
 
 -record(state, {
     oui :: non_neg_integer(),
-    subnets = [] :: [binary()],
-    devaddr_used = #{} :: map()
+    devaddr_bases = [] :: list(non_neg_integer()),
+    keys = #{} :: #{any() := non_neg_integer()}
 }).
 
 %% ------------------------------------------------------------------
@@ -61,8 +59,12 @@ start_link(Args) ->
 allocate(Device, PubKeyBin) ->
     gen_server:call(?SERVER, {allocate, Device, PubKeyBin}).
 
--spec sort_devices([router_device:device()], libp2p_crypto:pubkey_bin()) ->
-    [router_device:device()].
+-spec set_devaddr_bases(list(Range)) -> ok when Range :: non_neg_integer() | binary().
+set_devaddr_bases(Ranges) ->
+    ExpandedRanges = expand_ranges(Ranges),
+    gen_server:call(?MODULE, {set_devaddr_bases, ExpandedRanges}).
+
+-spec sort_devices([router_device:device()], libp2p_crypto:pubkey_bin()) -> [router_device:device()].
 sort_devices(Devices, PubKeyBin) ->
     case ?MODULE:pubkeybin_to_loc(PubKeyBin) of
         {error, _Reason} ->
@@ -79,28 +81,16 @@ pubkeybin_to_loc(undefined) ->
 pubkeybin_to_loc(PubKeyBin) ->
     router_blockchain:get_hotspot_location_index(PubKeyBin).
 
--spec net_id(number() | binary()) -> {ok, non_neg_integer()} | {error, invalid_net_id_type}.
-net_id(DevAddr) when erlang:is_number(DevAddr) ->
-    net_id(<<DevAddr:32/integer-unsigned>>);
-net_id(DevAddr) ->
-    try
-        Type = net_id_type(DevAddr),
-        NetID =
-            case Type of
-                0 -> get_net_id(DevAddr, 1, 6);
-                1 -> get_net_id(DevAddr, 2, 6);
-                2 -> get_net_id(DevAddr, 3, 9);
-                3 -> get_net_id(DevAddr, 4, 11);
-                4 -> get_net_id(DevAddr, 5, 12);
-                5 -> get_net_id(DevAddr, 6, 13);
-                6 -> get_net_id(DevAddr, 7, 15);
-                7 -> get_net_id(DevAddr, 8, 17)
-            end,
-        {ok, NetID bor (Type bsl 21)}
-    catch
-        throw:invalid_net_id_type:_ ->
-            {error, invalid_net_id_type}
-    end.
+-spec h3_parent_for_pubkeybin(undefined | libp2p_crypto:pubkey_bin()) -> non_neg_integer().
+h3_parent_for_pubkeybin(PubKeyBin) ->
+    Index =
+        case ?MODULE:pubkeybin_to_loc(PubKeyBin) of
+            {error, _} -> h3:from_geo({0.0, 0.0}, 12);
+            {ok, IA} -> IA
+        end,
+    h3:to_geo(
+        h3:parent(Index, router_utils:get_env_int(devaddr_allocate_resolution, 3))
+    ).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
@@ -116,43 +106,26 @@ init(Args) ->
     erlang:send_after(250, self(), post_init),
     {ok, #state{oui = OUI}}.
 
-handle_call({allocate, _Device, _PubKeyBin}, _From, #state{subnets = []} = State) ->
-    {reply, {error, no_subnet}, State};
+handle_call({set_devaddr_bases, Ranges}, _From, State) ->
+    NewState = State#state{devaddr_bases = Ranges, keys = #{}},
+    {reply, ok, NewState};
+handle_call({allocate, _Device, _PubKeyBin}, _From, #state{devaddr_bases = []} = State) ->
+    {reply, {error, no_subnets}, State};
 handle_call(
     {allocate, _Device, PubKeyBin},
     _From,
-    #state{subnets = Subnets, devaddr_used = Used} = State
+    #state{ devaddr_bases = Numbers, keys = Keys} = State
 ) ->
-    Index =
-        case ?MODULE:pubkeybin_to_loc(PubKeyBin) of
-            {error, _} -> h3:from_geo({0.0, 0.0}, 12);
-            {ok, IA} -> IA
-        end,
-    Parent = h3:to_geo(
-        h3:parent(Index, router_utils:get_env_int(devaddr_allocate_resolution, 3))
-    ),
-    {NthSubnet, DevaddrBase} =
-        case maps:get(Parent, Used, undefined) of
-            undefined ->
-                <<Base:25/integer-unsigned-big, _Mask:23/integer-unsigned-big>> = hd(Subnets),
-                {1, Base};
-            {Nth, LastBase} ->
-                Subnet = lists:nth(Nth, Subnets),
-                <<Base:25/integer-unsigned-big, Mask:23/integer-unsigned-big>> = Subnet,
-                Max = blockchain_ledger_routing_v1:subnet_mask_to_size(Mask),
-                case LastBase + 1 >= Base + Max of
-                    true ->
-                        {NextNth, NextSubnet} = next_subnet(Subnets, Nth),
-                        <<NextBase:25/integer-unsigned-big, _:23/integer-unsigned-big>> =
-                            NextSubnet,
-                        {NextNth, NextBase};
-                    false ->
-                        {Nth, LastBase + 1}
-                end
-        end,
+    Parent = ?MODULE:h3_parent_for_pubkeybin(PubKeyBin),
+
+    CurrentIndex = maps:get(Parent, Keys, 0),
+    DevaddrBase = lists:nth(CurrentIndex + 1, Numbers),
+    NextIndex = (CurrentIndex + 1) rem length(Numbers),
     DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+
     Reply = {ok, <<DevaddrBase:25/integer-unsigned-little, DevAddrPrefix:7/integer>>},
-    {reply, Reply, State#state{devaddr_used = maps:put(Parent, {NthSubnet, DevaddrBase}, Used)}};
+
+    {reply, Reply, State#state{keys = Keys#{Parent => NextIndex}}};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.
@@ -187,7 +160,8 @@ handle_info(
             {noreply, State};
         _ ->
             Subnets = router_blockchain:subnets_for_oui(OUI),
-            {noreply, State#state{subnets = Subnets}}
+            Ranges = expand_ranges(subnets_to_ranges(Subnets)),
+            {noreply, State#state{devaddr_bases = Ranges}}
     end;
 handle_info(_Msg, State) ->
     lager:warning("rcvd unknown info msg: ~p", [_Msg]),
@@ -203,12 +177,32 @@ terminate(_Reason, _State) ->
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
 
--spec next_subnet([binary()], non_neg_integer()) -> {non_neg_integer(), binary()}.
-next_subnet(Subnets, Nth) ->
-    case Nth + 1 > erlang:length(Subnets) of
-        true -> {1, lists:nth(1, Subnets)};
-        false -> {Nth + 1, lists:nth(Nth + 1, Subnets)}
-    end.
+-spec subnets_to_ranges(Subnets :: list(binary)) -> list({non_neg_integer(), non_neg_integer()}).
+subnets_to_ranges(Subnets) ->
+    lists:map(
+        fun(<<Base:25/integer-unsigned-big, Mask:23/integer-unsigned-big>>) ->
+            Max = blockchain_ledger_routing_v1:subnet_mask_to_size(Mask),
+            {Base, Base + Max - 1}
+        end,
+        Subnets
+    ).
+
+-spec expand_ranges(list({Min, Max})) -> [non_neg_integer()] when
+    Min :: non_neg_integer() | binary(),
+    Max :: non_neg_integer() | binary().
+expand_ranges(Ranges) ->
+    lists:flatmap(
+        fun
+            ({Start, End}) when erlang:is_number(Start) ->
+                lists:seq(Start, End);
+            ({StartHex, EndHex}) ->
+                lists:seq(
+                    erlang:binary_to_integer(StartHex, 16),
+                    erlang:binary_to_integer(EndHex, 16)
+                )
+        end,
+        Ranges
+    ).
 
 -spec distance_between(Device :: router_device:device(), Index :: h3:index()) -> non_neg_integer().
 distance_between(Device, Index) ->
@@ -238,35 +232,6 @@ indexes_to_lowest_res(Indexes) ->
 -spec to_res(h3:index(), non_neg_integer()) -> h3:index().
 to_res(Index, Res) ->
     h3:from_geo(h3:to_geo(Index), Res).
-
--spec net_id_type(binary()) -> 0..7.
-net_id_type(<<First:8/integer-unsigned, _/binary>>) ->
-    net_id_type(First, 7).
-
--spec net_id_type(non_neg_integer(), non_neg_integer()) -> 0..7.
-net_id_type(_, -1) ->
-    throw(invalid_net_id_type);
-net_id_type(Prefix, Index) ->
-    case Prefix band (1 bsl Index) of
-        0 -> 7 - Index;
-        _ -> net_id_type(Prefix, Index - 1)
-    end.
-
--spec get_net_id(binary(), non_neg_integer(), non_neg_integer()) -> non_neg_integer().
-get_net_id(DevAddr, PrefixLength, NwkIDBits) ->
-    <<Temp:32/integer-unsigned>> = DevAddr,
-    %% Remove type prefix
-    One = uint32(Temp bsl PrefixLength),
-    %% Remove NwkAddr suffix
-    Two = uint32(One bsr (32 - NwkIDBits)),
-
-    IgnoreSize = 32 - NwkIDBits,
-    <<_:IgnoreSize, NetID:NwkIDBits/integer-unsigned>> = <<Two:32/integer-unsigned>>,
-    NetID.
-
--spec uint32(integer()) -> integer().
-uint32(Num) ->
-    Num band 4294967295.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests
@@ -370,84 +335,77 @@ to_res_test() ->
     ?assertEqual(?INDEX_D, to_res(?INDEX_D, 12)),
     ok.
 
-net_id_test() ->
-    lists:foreach(
-        fun(#{expect := Expect, bin := Bin, num := Num, msg := Msg}) ->
-            %% Make sure Bin and Num are the same thing
-            Bin = <<Num:32>>,
-            ?assertEqual(Expect, net_id(Bin), "BIN: " ++ Msg),
-            ?assertEqual(Expect, net_id(Num), "NUM: " ++ Msg)
+set_range_allocation_test_() ->
+    [
+        ?_test(test_no_subnet()),
+        ?_test(test_subnet_wrap()),
+        %% ?_test(test_multiple_keys()),
+        ?_test(test_non_sequential_subnet()),
+        ?_test(test_replace_range())
+    ].
+
+test_no_subnet() ->
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    ?assertMatch(
+        {reply, {error, no_subnets}, _State},
+        handle_call({allocate, no_device, PubKeyBin}, self(), #state{})
+    ),
+    ok.
+
+test_subnet_wrap() ->
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    {Addrs, _State} = collect_n_addrs(10, PubKeyBin, #state{devaddr_bases = expand_ranges([{1, 5}])}),
+
+    ?assertEqual(as_devaddrs([1, 2, 3, 4, 5, 1, 2, 3, 4, 5]), Addrs),
+    ok.
+
+test_non_sequential_subnet() ->
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    State = #state{devaddr_bases = expand_ranges([{1, 2}, {9, 10}])},
+    {Addrs, _State} = collect_n_addrs(9, PubKeyBin, State),
+
+    ?assertEqual(as_devaddrs([1, 2, 9, 10, 1, 2, 9, 10, 1]), Addrs),
+    ok.
+
+test_replace_range() ->
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    %% ok = ?MODULE:set_devaddr_bases([{1, 3}]),
+    State0 = #state{devaddr_bases = expand_ranges([{1, 3}])},
+    {Addrs1, State1} = collect_n_addrs(5, PubKeyBin, State0),
+    ?assertEqual(as_devaddrs([1, 2, 3, 1, 2]), Addrs1),
+
+    {reply, ok, State2} = handle_call(
+        {set_devaddr_bases, expand_ranges([{10, 30}])}, self(), State1
+    ),
+    {Addrs2, _State3} = collect_n_addrs(5, PubKeyBin, State2),
+    ?assertEqual(as_devaddrs([10, 11, 12, 13, 14]), Addrs2),
+    ok.
+
+collect_n_addrs(N, Key, StartState) ->
+    lists:foldl(
+        fun(_Idx, {Addrs, State0}) ->
+            {reply, {ok, Addr}, State1} = ?MODULE:handle_call(
+                {allocate, no_device, Key}, self(), State0
+            ),
+            {Addrs ++ [Addr], State1}
         end,
-        [
-            #{
-                expect => {ok, 16#00002D},
-                num => 1543503871,
-                bin => <<91, 255, 255, 255>>,
-                %% truncated byte output == hex == integer
-                msg => "[45] == 2D == 45 type 0"
-            },
-            #{
-                expect => {ok, 16#20002D},
-                num => 2919235583,
-                bin => <<173, 255, 255, 255>>,
-                msg => "[45] == 2D == 45 type 1"
-            },
-            #{
-                expect => {ok, 16#40016D},
-                num => 3605004287,
-                bin => <<214, 223, 255, 255>>,
-                msg => "[1,109] == 16D == 365 type 2"
-            },
-            #{
-                expect => {ok, 16#6005B7},
-                num => 3949985791,
-                bin => <<235, 111, 255, 255>>,
-                msg => "[5,183] == 5B7 == 1463 type 3"
-            },
-            #{
-                expect => {ok, 16#800B6D},
-                num => 4122411007,
-                bin => <<245, 182, 255, 255>>,
-                msg => "[11, 109] == B6D == 2925 type 4"
-            },
-            #{
-                expect => {ok, 16#A016DB},
-                num => 4208689151,
-                bin => <<250, 219, 127, 255>>,
-                msg => "[22,219] == 16DB == 5851 type 5"
-            },
-            #{
-                expect => {ok, 16#C05B6D},
-                num => 4251826175,
-                bin => <<253, 109, 183, 255>>,
-                msg => "[91, 109] == 5B6D == 23405 type 6"
-            },
-            #{
-                expect => {ok, 16#E16DB6},
-                num => 4273396607,
-                bin => <<254, 182, 219, 127>>,
-                msg => "[1,109,182] == 16DB6 == 93622 type 7"
-            },
-            #{
-                expect => {error, invalid_net_id_type},
-                num => 4294967295,
-                bin => <<255, 255, 255, 255>>,
-                msg => "Invalid DevAddr"
-            },
-            #{
-                expect => {ok, 16#000000},
-                %% Way under 32 bit number
-                num => 46377,
-                bin => <<0, 0, 181, 41>>,
-                msg => "[0] == 0 == 0"
-            },
-            #{
-                expect => {ok, 16#200029},
-                num => 2838682043,
-                bin => <<169, 50, 217, 187>>,
-                msg => "[41] == 29 == 41 type 1"
-            }
-        ]
+        {[], StartState},
+        lists:seq(1, N)
     ).
+
+as_devaddrs(Xs) -> lists:reverse(as_devaddrs(Xs, [])).
+
+as_devaddrs([], Acc) ->
+    Acc;
+as_devaddrs([X | Xs], Acc) ->
+    as_devaddrs(Xs, [<<X, 0, 0, $H>> | Acc]).
 
 -endif.

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -248,7 +248,7 @@ get_devaddrs(Pid, #state{sig_fun = SigFun, route_id = RouteID}) ->
 
 -spec forward_reconcile(
     Pid :: pid() | undefined,
-    Result :: {ok, non_neg_integer(), non_neg_integer()} | {error, any()}
+    Result :: list(iot_config_pb:iot_config_devaddr_range_v1_pb()) | {error, any()}
 ) -> ok.
 forward_reconcile(undefined, _Result) ->
     ok;

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -187,6 +187,9 @@ handle_info({trailers, _StreamID, _Data}, State) ->
 handle_info({eos, _StreamID}, State) ->
     lager:debug("got eos for stream: ~p", [_StreamID]),
     {noreply, State};
+handle_info({'END_STREAM', _StreamID}, State) ->
+    lager:debug("got END_STREAM for stream: ~p", [_StreamID]),
+    {noreply, State};
 handle_info({'DOWN', _Ref, Type, Pid, Reason}, State) ->
     lager:debug("~p got DOWN for ~p: ~p ~p with state ~p", [self(), Type, Pid, Reason, State]),
     {noreply, State};

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -71,6 +71,7 @@ start_link(Args) ->
                     gen_server:start_link({local, ?SERVER}, ?SERVER, Map, [])
             end;
         _ ->
+            lager:warning("~s ignored ~p", [?MODULE, Args]),
             ignore
     end.
 
@@ -233,7 +234,7 @@ get_devaddrs(Pid, #state{sig_fun = SigFun, route_id = RouteID}) ->
     SignedReq = Req#iot_config_route_get_devaddr_ranges_req_v1_pb{signature = SigFun(EncodedReq)},
 
     helium_iot_config_route_client:get_devaddr_ranges(SignedReq, #{
-        channel => ?MODULE,
+        channel => router_ics_utils:channel(),
         callback_module => {
             router_ics_route_get_devaddrs_handler,
             Pid

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -67,7 +67,7 @@ start_link(#{devaddr_enabled := "true", host := Host, port := Port} = Args) when
 ->
     case maps:get(route_id, Args) of
         undefined ->
-            lager:warn("~p enabled, but no route_id provided, ignoring", [?MODULE]),
+            lager:warning("~p enabled, but no route_id provided, ignoring", [?MODULE]),
             ignore;
         _ ->
             gen_server:start_link({local, ?SERVER}, ?SERVER, Args, [])

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -110,9 +110,6 @@ init(
         route_id = RouteID
     }}.
 
-handle_call(_Msg, _From, #state{route_id = undefined} = State) ->
-    lager:warning("can't handle call msg: ~p", [_Msg]),
-    {reply, ok, State};
 handle_call(get_devaddr_ranges, _From, #state{devaddr_ranges = DevaddrRanges} = State) ->
     Reply =
         case DevaddrRanges of

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -1,0 +1,281 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Router IOT Config Service Worker ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(router_ics_devaddr_worker).
+
+-behavior(gen_server).
+
+-include("./autogen/iot_config_pb.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+-export([
+    start_link/1,
+    get_devaddr_ranges/0,
+    reconcile/1,
+    reconcile_end/2
+]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(SERVER, ?MODULE).
+-define(INIT, init).
+-define(RECONCILE_START, reconcile_start).
+-define(RECONCILE_END, reconcile_end).
+
+-ifdef(TEST).
+-define(BACKOFF_MIN, 100).
+-else.
+-define(BACKOFF_MIN, timer:seconds(10)).
+-endif.
+-define(BACKOFF_MAX, timer:minutes(5)).
+
+-record(state, {
+    pubkey_bin :: libp2p_crypto:pubkey_bin(),
+    sig_fun :: function(),
+    host :: string(),
+    port :: non_neg_integer(),
+    conn_backoff :: backoff:backoff(),
+    route_id :: undefined | string(),
+    devaddr_ranges :: undefined | list(iot_config_pb:iot_config_devaddr_range_v1_pb())
+}).
+
+-type state() :: #state{}.
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+start_link(#{host := ""}) ->
+    ignore;
+start_link(#{port := Port} = Args) when is_list(Port) ->
+    ?MODULE:start_link(Args#{port => erlang:list_to_integer(Port)});
+start_link(#{devaddr_enabled := "true", host := Host, port := Port} = Args) when
+    is_list(Host) andalso is_integer(Port)
+->
+    gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []);
+start_link(_Args) ->
+    ignore.
+
+-spec get_devaddr_ranges() ->
+    {ok, list(iot_config_pb:iot_config_devaddr_range_v1_pb())} | {error, any()}.
+get_devaddr_ranges() ->
+    gen_server:call(?SERVER, get_devaddr_ranges).
+
+-spec reconcile(Pid :: pid() | undefined) -> ok.
+reconcile(Pid) ->
+    gen_server:cast(?SERVER, {?RECONCILE_START, Pid}).
+
+-spec reconcile_end(Pid :: pid() | undefined, list(iot_config_pb:iot_config_devaddr_range_v1_pb())) ->
+    ok.
+reconcile_end(Pid, List) ->
+    gen_server:cast(?SERVER, {?RECONCILE_END, Pid, List}).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+init(#{pubkey_bin := PubKeyBin, sig_fun := SigFun, host := Host, port := Port} = Args) ->
+    lager:info("~p init with ~p", [?SERVER, Args]),
+    {ok, _, SigFun, _} = blockchain_swarm:keys(),
+    Backoff = backoff:type(backoff:init(?BACKOFF_MIN, ?BACKOFF_MAX), normal),
+    self() ! ?INIT,
+    {ok, #state{
+        pubkey_bin = PubKeyBin,
+        sig_fun = SigFun,
+        host = Host,
+        port = Port,
+        conn_backoff = Backoff,
+        route_id = maps:get(route_id, Args, undefined)
+    }}.
+
+handle_call(_Msg, _From, #state{route_id = undefined} = State) ->
+    lager:warning("can't handle call msg: ~p", [_Msg]),
+    {reply, ok, State};
+handle_call(get_devaddr_ranges, _From, #state{devaddr_ranges = DevaddrRanges} = State) ->
+    Reply =
+        case DevaddrRanges of
+            undefined -> {error, no_ranges};
+            _ -> {ok, DevaddrRanges}
+        end,
+    {reply, Reply, State};
+handle_call(_Msg, _From, State) ->
+    lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
+    {reply, ok, State}.
+
+handle_cast({?RECONCILE_START, Pid}, #state{conn_backoff = Backoff0} = State) ->
+    ct:print("reconciling started pid: ~p", [Pid]),
+    case get_devaddrs(Pid, State) of
+        {error, _Reason} = Error ->
+            {Delay, Backoff1} = backoff:fail(Backoff0),
+            _ = erlang:send_after(Delay, self(), ?INIT),
+            lager:warning("fail to get_devaddrs ~p, retrying in ~wms", [
+                _Reason, Delay
+            ]),
+            ok = forward_reconcile(Pid, Error),
+            {noreply, State#state{conn_backoff = Backoff1}};
+        {ok, _Stream} ->
+            {_, Backoff2} = backoff:succeed(Backoff0),
+            {noreply, State#state{conn_backoff = Backoff2}}
+    end;
+handle_cast({?RECONCILE_END, Pid, DevaddrRanges}, #state{} = State) ->
+    ct:print("reconciling done: ~p", [{?RECONCILE_END, Pid, DevaddrRanges}]),
+    ok = forward_reconcile(Pid, DevaddrRanges),
+    {noreply, State#state{devaddr_ranges = DevaddrRanges}};
+handle_cast(_Msg, State) ->
+    lager:warning("rcvd unknown cast msg: ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info(?INIT, #state{conn_backoff = Backoff0} = State) ->
+    {Delay, Backoff1} = backoff:fail(Backoff0),
+    case connect(State) of
+        {error, _Reason} ->
+            lager:warning("fail to connect ~p, reconnecting in ~wms", [_Reason, Delay]),
+            _ = erlang:send_after(Delay, self(), ?INIT),
+            {noreply, State#state{conn_backoff = Backoff1}};
+        ok ->
+            case get_route_id(State) of
+                {error, _Reason} ->
+                    _ = erlang:send_after(Delay, self(), ?INIT),
+                    lager:warning("fail to get_route_id ~p, reconnecting in ~wms", [_Reason, Delay]),
+                    {noreply, State#state{conn_backoff = Backoff1}};
+                {ok, RouteID} ->
+                    lager:info("connected"),
+                    {_, Backoff2} = backoff:succeed(Backoff0),
+                    ok = ?MODULE:reconcile(undefined),
+                    {noreply, State#state{
+                        conn_backoff = Backoff2, route_id = RouteID
+                    }}
+            end
+    end;
+handle_info({headers, _StreamID, _Data}, State) ->
+    ct:print("got headers for stream: ~p, ~p", [_StreamID, _Data]),
+    {noreply, State};
+handle_info({trailers, _StreamID, _Data}, State) ->
+    ct:print("got trailers for stream: ~p, ~p", [_StreamID, _Data]),
+    {noreply, State};
+handle_info({eos, _StreamID}, State) ->
+    ct:print("got eos for stream: ~p", [_StreamID]),
+    {noreply, State};
+handle_info({'DOWN', _Ref, Type, Pid, Reason}, State) ->
+    ct:print("~p got DOWN for ~p: ~p ~p with state ~p", [self(), Type, Pid, Reason, State]),
+    {noreply, State};
+handle_info(_Msg, State) ->
+    ct:print("rcvd unknown info msg: ~p", [_Msg]),
+    {noreply, State}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+-spec connect(State :: state()) -> ok | {error, any()}.
+connect(#state{host = Host, port = Port} = State) ->
+    case grpcbox_channel:pick(?MODULE, stream) of
+        {error, _} ->
+            case
+                grpcbox_client:connect(?MODULE, [{http, Host, Port, []}], #{
+                    sync_start => true
+                })
+            of
+                {ok, _Conn} ->
+                    ct:print("initial connected: ~p", [_Conn]),
+                    connect(State);
+                {error, _Reason} = Error ->
+                    Error
+            end;
+        {ok, {_Conn, _Interceptor}} ->
+            ct:print("found connected: ~p and ~p", [_Conn, _Interceptor]),
+            erlang:monitor(process, _Conn),
+            ok
+    end.
+
+-spec get_route_id(state()) -> {ok, string()} | {error, any()}.
+get_route_id(#state{sig_fun = SigFun, route_id = undefined}) ->
+    Req = #iot_config_route_list_req_v1_pb{
+        oui = router_utils:get_oui(),
+        timestamp = erlang:system_time(millisecond)
+    },
+    EncodedReq = iot_config_pb:encode_msg(Req, iot_config_route_list_req_v1_pb),
+    SignedReq = Req#iot_config_route_list_req_v1_pb{signature = SigFun(EncodedReq)},
+    case helium_iot_config_route_client:list(SignedReq, #{channel => ?MODULE}) of
+        {grpc_error, Reason} ->
+            {error, Reason};
+        {error, _} = Error ->
+            Error;
+        {ok, #iot_config_route_list_res_v1_pb{routes = []}, _Meta} ->
+            {error, no_routes};
+        {ok, #iot_config_route_list_res_v1_pb{routes = [Route]}, _Meta} ->
+            RouteID = Route#iot_config_route_v1_pb.id,
+            lager:info(
+                lists:join(" ", [
+                    "Picking devaddr range from route ~s.",
+                    "Add 'ROUTER_DEVADDR_CONFIG_SERVICE_ROUTE_ID=~s' to your .env file."
+                ]),
+                [RouteID, RouteID]
+            ),
+            {ok, RouteID};
+        {ok, #iot_config_route_list_res_v1_pb{routes = [Route | _] = Routes}, _Meta} ->
+            RouteID = Route#iot_config_route_v1_pb.id,
+
+            Count = io_lib:format("There are ~p routes, choosing ~s", [length(Routes), RouteID]),
+            Info = "Add one of the following to your .env file:",
+            Choices = lists:map(
+                fun(R) ->
+                    io_lib:format("  ROUTER_DEVADDR_CONFIG_SERVICE_ROUTE_ID=~s", [
+                        R#iot_config_route_v1_pb.id
+                    ])
+                end,
+                Routes
+            ),
+
+            lager:info("~p~n~p~n~p", [Count, Info, lists:join("\n", Choices)]),
+
+            {ok, RouteID}
+    end;
+get_route_id(#state{route_id = RouteID}) ->
+    {ok, RouteID}.
+
+-spec get_devaddrs(Pid :: pid() | undefined, state()) ->
+    {ok, grpcbox_client:stream()} | {error, any()}.
+get_devaddrs(Pid, #state{sig_fun = SigFun, route_id = RouteID}) ->
+    Req = #iot_config_route_get_devaddr_ranges_req_v1_pb{
+        route_id = RouteID,
+        timestamp = erlang:system_time(millisecond)
+    },
+    EncodedReq = iot_config_pb:encode_msg(Req, iot_config_route_get_devaddr_ranges_req_v1_pb),
+    SignedReq = Req#iot_config_route_get_devaddr_ranges_req_v1_pb{signature = SigFun(EncodedReq)},
+
+    helium_iot_config_route_client:get_devaddr_ranges(SignedReq, #{
+        channel => ?MODULE,
+        callback_module => {
+            router_ics_route_get_devaddrs_handler,
+            Pid
+        }
+    }).
+
+-spec forward_reconcile(
+    Pid :: pid() | undefined,
+    Result :: {ok, non_neg_integer(), non_neg_integer()} | {error, any()}
+) -> ok.
+forward_reconcile(undefined, _Result) ->
+    ok;
+forward_reconcile(Pid, Result) ->
+    catch Pid ! {?MODULE, Result},
+    ok.

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -179,19 +179,19 @@ handle_info(?INIT, #state{conn_backoff = Backoff0, route_id = RouteID} = State) 
             }}
     end;
 handle_info({headers, _StreamID, _Data}, State) ->
-    ct:print("got headers for stream: ~p, ~p", [_StreamID, _Data]),
+    lager:debug("got headers for stream: ~p, ~p", [_StreamID, _Data]),
     {noreply, State};
 handle_info({trailers, _StreamID, _Data}, State) ->
-    ct:print("got trailers for stream: ~p, ~p", [_StreamID, _Data]),
+    lager:debug("got trailers for stream: ~p, ~p", [_StreamID, _Data]),
     {noreply, State};
 handle_info({eos, _StreamID}, State) ->
-    ct:print("got eos for stream: ~p", [_StreamID]),
+    lager:debug("got eos for stream: ~p", [_StreamID]),
     {noreply, State};
 handle_info({'DOWN', _Ref, Type, Pid, Reason}, State) ->
-    ct:print("~p got DOWN for ~p: ~p ~p with state ~p", [self(), Type, Pid, Reason, State]),
+    lager:debug("~p got DOWN for ~p: ~p ~p with state ~p", [self(), Type, Pid, Reason, State]),
     {noreply, State};
 handle_info(_Msg, State) ->
-    ct:print("rcvd unknown info msg: ~p", [_Msg]),
+    lager:debug("rcvd unknown info msg: ~p", [_Msg]),
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -65,6 +65,7 @@ start_link(Args) ->
         #{eui_enabled := "true"} = Map ->
             gen_server:start_link({local, ?SERVER}, ?SERVER, Map, []);
         _ ->
+            lager:warning("~s ignored ~p", [?MODULE, Args]),
             ignore
     end.
 

--- a/src/grpc/router_ics_gateway_location_worker.erl
+++ b/src/grpc/router_ics_gateway_location_worker.erl
@@ -64,6 +64,7 @@
 start_link(Args) ->
     case router_ics_utils:start_link_args(Args) of
         ignore ->
+            lager:warning("~s ignored ~p", [?MODULE, Args]),
             ignore;
         Map ->
             gen_server:start_link({local, ?SERVER}, ?SERVER, Map, [])

--- a/src/grpc/router_ics_route_get_devaddrs_handler.erl
+++ b/src/grpc/router_ics_route_get_devaddrs_handler.erl
@@ -22,12 +22,12 @@
 
 -spec init(pid(), stream_id(), Pid :: pid() | undefined) -> {ok, state()}.
 init(_ConnectionPid, _StreamId, Pid) ->
-    ct:print("init ~p: ~p", [_StreamId, Pid]),
+    lager:info("init ~p: ~p", [_StreamId, Pid]),
     {ok, #state{pid = Pid, data = []}}.
 
 -spec handle_message(iot_config_pb:iot_config_devaddr_range_v1_pb(), state()) -> {ok, state()}.
 handle_message(DevaddrRange, #state{data = Data} = State) ->
-    ct:print("got ~p", [DevaddrRange]),
+    lager:info("got ~p", [DevaddrRange]),
     {ok, State#state{data = [DevaddrRange | Data]}}.
 
 -spec handle_headers(map(), state()) -> {ok, state()}.
@@ -40,6 +40,6 @@ handle_trailers(_Status, _Message, _Metadata, CBData) ->
 
 -spec handle_eos(state()) -> {ok, state()}.
 handle_eos(#state{pid = Pid, data = Data} = State) ->
-    ct:print("got eos, sending to router_ics_devaddr_worker"),
+    lager:info("got eos, sending to router_ics_devaddr_worker"),
     ok = router_ics_devaddr_worker:reconcile_end(Pid, Data),
     {ok, State}.

--- a/src/grpc/router_ics_route_get_devaddrs_handler.erl
+++ b/src/grpc/router_ics_route_get_devaddrs_handler.erl
@@ -1,0 +1,45 @@
+-module(router_ics_route_get_devaddrs_handler).
+
+-behaviour(grpcbox_client_stream).
+
+%% -include("./autogen/iot_config_pb.hrl").
+
+-export([
+    init/3,
+    handle_message/2,
+    handle_headers/2,
+    handle_trailers/4,
+    handle_eos/1
+]).
+
+-record(state, {
+    pid :: pid() | undefined,
+    data :: list(iot_config_pb:iot_config_devaddr_range_v1_pb())
+}).
+
+-type stream_id() :: non_neg_integer().
+-type state() :: #state{}.
+
+-spec init(pid(), stream_id(), Pid :: pid() | undefined) -> {ok, state()}.
+init(_ConnectionPid, _StreamId, Pid) ->
+    ct:print("init ~p: ~p", [_StreamId, Pid]),
+    {ok, #state{pid = Pid, data = []}}.
+
+-spec handle_message(iot_config_pb:iot_config_devaddr_range_v1_pb(), state()) -> {ok, state()}.
+handle_message(DevaddrRange, #state{data = Data} = State) ->
+    ct:print("got ~p", [DevaddrRange]),
+    {ok, State#state{data = [DevaddrRange | Data]}}.
+
+-spec handle_headers(map(), state()) -> {ok, state()}.
+handle_headers(_Metadata, CBData) ->
+    {ok, CBData}.
+
+-spec handle_trailers(binary(), term(), map(), state()) -> {ok, state()}.
+handle_trailers(_Status, _Message, _Metadata, CBData) ->
+    {ok, CBData}.
+
+-spec handle_eos(state()) -> {ok, state()}.
+handle_eos(#state{pid = Pid, data = Data} = State) ->
+    ct:print("got eos, sending to router_ics_devaddr_worker"),
+    ok = router_ics_devaddr_worker:reconcile_end(Pid, Data),
+    {ok, State}.

--- a/src/grpc/router_ics_route_get_euis_handler.erl
+++ b/src/grpc/router_ics_route_get_euis_handler.erl
@@ -2,8 +2,6 @@
 
 -behaviour(grpcbox_client_stream).
 
-%% -include("./autogen/iot_config_pb.hrl").
-
 -export([
     init/3,
     handle_message/2,

--- a/src/grpc/router_ics_route_get_euis_handler.erl
+++ b/src/grpc/router_ics_route_get_euis_handler.erl
@@ -2,7 +2,7 @@
 
 -behaviour(grpcbox_client_stream).
 
--include("./autogen/iot_config_pb.hrl").
+%% -include("./autogen/iot_config_pb.hrl").
 
 -export([
     init/3,

--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -64,6 +64,7 @@ start_link(Args) ->
         #{skf_enabled := "true"} = Map ->
             gen_server:start_link({local, ?SERVER}, ?SERVER, Map, []);
         _ ->
+            lager:warning("~s ignored ~p", [?MODULE, Args]),
             ignore
     end.
 

--- a/src/router_sup.erl
+++ b/src/router_sup.erl
@@ -146,6 +146,7 @@ init([]) ->
             ?SUP(router_decoder_sup, []),
             ?WORKER(router_device_devaddr, [#{}]),
             ?WORKER(router_xor_filter_worker, [#{}]),
+            ?WORKER(router_ics_devaddr_worker, [ICSOpts]),
             ?WORKER(router_ics_eui_worker, [ICSOpts]),
             ?WORKER(router_ics_skf_worker, [ICSOpts]),
             ?WORKER(router_ics_gateway_location_worker, [ICSOpts])

--- a/src/router_utils.erl
+++ b/src/router_utils.erl
@@ -35,6 +35,7 @@
     get_env_bool/2,
     enumerate_0/1,
     enumerate_0_to_size/3,
+    enumerate_last/1,
     metadata_fun/0,
     random_non_miner_predicate/1
 ]).
@@ -869,6 +870,11 @@ trace_file(<<BinFileName:5/binary, _/binary>>) ->
 enumerate_0(L) ->
     lists:zip(lists:seq(0, erlang:length(L) - 1), L).
 
+-spec enumerate_last(list(T)) -> list({Last :: boolean(), T}).
+enumerate_last(L) ->
+    Last = erlang:length(L),
+    [{Idx + 1 == Last, El} || {Idx, El} <- enumerate_0(L)].
+
 -spec enumerate_0_to_size(list({integer(), T}), integer(), T) -> list({integer(), T}).
 enumerate_0_to_size(IndexedList, Max, Default) ->
     Needed = Max - length(IndexedList),
@@ -890,6 +896,13 @@ enumerate_0_to_size_test_() ->
     [
         ?_assertEqual([{0, default}], enumerate_0_to_size([], 1, default)),
         ?_assertEqual([{0, zero}, {1, default}], enumerate_0_to_size([{0, zero}], 2, default))
+    ].
+
+enumerate_last_test_() ->
+    [
+        ?_assertEqual([], enumerate_last([])),
+        ?_assertEqual([{true, val}], enumerate_last([val])),
+        ?_assertEqual([{false, val1}, {true, val2}], enumerate_last([val1, val2]))
     ].
 
 trace_test() ->

--- a/test/router_ics_devaddr_worker_SUITE.erl
+++ b/test/router_ics_devaddr_worker_SUITE.erl
@@ -1,0 +1,228 @@
+-module(router_ics_devaddr_worker_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("../src/grpc/autogen/iot_config_pb.hrl").
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    main_test/1,
+    server_crash_test/1,
+    multiple_routes_test/1,
+    route_id_from_env_test/1
+]).
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [
+        main_test,
+        server_crash_test,
+        multiple_routes_test,
+        route_id_from_env_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    persistent_term:put(router_test_ics_route_service, self()),
+    Port = 8085,
+    ServerPid = start_server(Port),
+    ok = application:set_env(
+        router,
+        ics,
+        #{devaddr_enabled => "true", host => "localhost", port => Port},
+        [{persistent, true}]
+    ),
+    ok =
+        case TestCase of
+            multiple_routes_test ->
+                application:set_env(router, test_route_list, [
+                    #iot_config_route_v1_pb{id = "route-id-1"},
+                    #iot_config_route_v1_pb{id = "route-id-2"}
+                ]),
+                ok;
+            route_id_from_env_test ->
+                ok = application:set_env(
+                    router,
+                    ics,
+                    #{
+                        devaddr_enabled => "true",
+                        host => "localhost",
+                        port => Port,
+                        route_id => "route-id-from-env"
+                    },
+                    [{persistent, true}]
+                );
+            _ ->
+                ok
+        end,
+
+    test_utils:init_per_testcase(TestCase, [{ics_server, ServerPid} | Config]).
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(TestCase, Config) ->
+    test_utils:end_per_testcase(TestCase, Config),
+    ServerPid = proplists:get_value(ics_server, Config),
+    case erlang:is_process_alive(ServerPid) of
+        true -> gen_server:stop(ServerPid);
+        false -> ok
+    end,
+    _ = application:stop(grpcbox),
+    ok = application:set_env(
+        router,
+        ics,
+        #{},
+        [{persistent, true}]
+    ),
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+main_test(_Config) ->
+    RouteID = "test_route_id",
+    ok = router_test_ics_route_service:devaddr_range(
+        #iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2},
+        true
+    ),
+
+    [{Type0, _Req0}, {Type1, _Req1}] = rcv_loop(),
+    ?assertEqual(list, Type0),
+    ?assertEqual(get_devaddr_ranges, Type1),
+
+    ?assertEqual(
+        {ok, [#iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2}]},
+        router_ics_devaddr_worker:get_devaddr_ranges()
+    ),
+
+    ok.
+
+multiple_routes_test(_Config) ->
+    RouteID = "route-id-1",
+    ok = router_test_ics_route_service:devaddr_range(
+        #iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2},
+        true
+    ),
+
+    [{Type0, _Req0}, {Type1, Req1}] = rcv_loop(),
+    ?assertEqual(list, Type0),
+    ?assertEqual(get_devaddr_ranges, Type1),
+    %% Make sure we requested devaddr ranges for the first route in the list.
+    ?assertEqual(RouteID, Req1#iot_config_route_get_devaddr_ranges_req_v1_pb.route_id),
+
+    ?assertEqual(
+        {ok, [#iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2}]},
+        router_ics_devaddr_worker:get_devaddr_ranges()
+    ),
+
+    ok.
+
+route_id_from_env_test(_Config) ->
+    RouteID = "route-id-from-env",
+    ok = router_test_ics_route_service:devaddr_range(
+        #iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2},
+        true
+    ),
+
+    [{Type0, Req0}] = rcv_loop(),
+    ?assertNotEqual(list, Type0),
+    ?assertEqual(get_devaddr_ranges, Type0),
+    %% Make sure we requested devaddr ranges for the first route in the list.
+    ?assertEqual(RouteID, Req0#iot_config_route_get_devaddr_ranges_req_v1_pb.route_id),
+
+    ?assertEqual(
+        {ok, [#iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2}]},
+        router_ics_devaddr_worker:get_devaddr_ranges()
+    ),
+
+    ok.
+
+server_crash_test(_Config) ->
+    %% NOTE: The Devaddr worker is not like the other workers because it's
+    %% purpose is to grab 1 bit of information on startup. Because it's not
+    %% continually using the connection to the config service, it will never
+    %% know if the config server went down _after_ it fetched the information it
+    %% needs.
+
+    %% RouteID = "test_route_id",
+    %% ok = router_test_ics_route_service:devaddr_range(
+    %%     #iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2},
+    %%     true
+    %% ),
+
+    %% %% Fetch the route and devaddr_ranges on startup
+    %% [{Type0, _Req0}, {Type1, _Req1}] = rcv_loop(),
+    %% ?assertEqual(list, Type0),
+    %% ?assertEqual(get_devaddr_ranges, Type1),
+
+    %% %% ===================================================================
+    %% %% kill and restart the test server
+    %% ok = gen_server:stop(proplists:get_value(ics_server, Config)),
+    %% lager:notice("server stopped"),
+    %% timer:sleep(250),
+
+    %% ServerPid = start_server(8085),
+    %% timer:sleep(1000),
+    %% lager:notice("server started"),
+
+    %% %% ===================================================================
+    %% %% Refetch the route and devaddr ranges when the connection comes back
+    %% ok = router_test_ics_route_service:devaddr_range(
+    %%     #iot_config_devaddr_range_v1_pb{route_id = RouteID, start_addr = 1, end_addr = 2},
+    %%     true
+    %% ),
+
+    %% [{Type2, _Req2}, {Type3, _Req3}] = rcv_loop(),
+    %% ?assertEqual(list, Type2),
+    %% ?assertEqual(get_devaddr_ranges, Type3),
+
+    %% ok = gen_server:stop(ServerPid),
+
+    ok.
+
+%% ------------------------------------------------------------------
+%% Helper functions
+%% ------------------------------------------------------------------
+
+start_server(Port) ->
+    _ = application:ensure_all_started(grpcbox),
+    {ok, ServerPid} = grpcbox:start_server(#{
+        grpc_opts => #{
+            service_protos => [iot_config_pb],
+            services => #{
+                'helium.iot_config.route' => router_test_ics_route_service
+            }
+        },
+        listen_opts => #{port => Port, ip => {0, 0, 0, 0}}
+    }),
+    ServerPid.
+
+rcv_loop() ->
+    lists:reverse(rcv_loop([])).
+
+rcv_loop(Acc) ->
+    receive
+        {router_test_ics_route_service, Type, Req} ->
+            lager:notice("got router_test_ics_route_service ~p req ~p", [Type, Req]),
+            rcv_loop([{Type, Req} | Acc])
+    after timer:seconds(2) ->
+        Acc
+    end.

--- a/test/router_ics_devaddr_worker_SUITE.erl
+++ b/test/router_ics_devaddr_worker_SUITE.erl
@@ -11,6 +11,7 @@
 
 -export([
     main_test/1,
+    ignore_ranges_outside_net_id_test/1,
     server_crash_test/1
 ]).
 
@@ -27,6 +28,7 @@
 all() ->
     [
         main_test,
+        ignore_ranges_outside_net_id_test,
         server_crash_test
     ].
 
@@ -75,19 +77,62 @@ end_per_testcase(TestCase, Config) ->
 %%--------------------------------------------------------------------
 
 main_test(_Config) ->
-    Range = #iot_config_devaddr_range_v1_pb{
-        route_id = "test_route_id", start_addr = 1, end_addr = 2
+    Range1 = #iot_config_devaddr_range_v1_pb{
+        route_id = "test_route_id",
+        start_addr = binary:decode_unsigned(binary:decode_hex(<<"48000000">>)),
+        end_addr = binary:decode_unsigned(binary:decode_hex(<<"48000007">>))
+    },
+    Range2 = #iot_config_devaddr_range_v1_pb{
+        route_id = "test_route_id",
+        start_addr = binary:decode_unsigned(binary:decode_hex(<<"48000020">>)),
+        end_addr = binary:decode_unsigned(binary:decode_hex(<<"48000022">>))
     },
 
-
-    ok = router_test_ics_route_service:devaddr_ranges([Range]),
+    ok = router_test_ics_route_service:devaddr_ranges([Range1, Range2]),
     timer:sleep(100),
 
     ?assertMatch([{get_devaddr_ranges, _Req}], rcv_loop()),
 
     ?assertEqual(
-        {ok, [Range]},
+        {ok, [Range2, Range1]},
         router_ics_devaddr_worker:get_devaddr_ranges()
+    ),
+
+    ?assertEqual(
+        {ok, lists:seq(0, 7) ++ lists:seq(32, 34)},
+        router_device_devaddr:get_devaddr_bases()
+    ),
+
+    ok.
+
+ignore_ranges_outside_net_id_test(_Config) ->
+    Range1 = #iot_config_devaddr_range_v1_pb{
+        route_id = "test_route_id",
+        start_addr = binary:decode_unsigned(binary:decode_hex(<<"48000000">>)),
+        end_addr = binary:decode_unsigned(binary:decode_hex(<<"48000007">>))
+    },
+
+    Range2 = #iot_config_devaddr_range_v1_pb{
+        route_id = "test_route_id",
+        start_addr = binary:decode_unsigned(binary:decode_hex(<<"72000008">>)),
+        end_addr = binary:decode_unsigned(binary:decode_hex(<<"7200000F">>))
+    },
+
+    ok = router_test_ics_route_service:devaddr_ranges([Range1, Range2]),
+    timer:sleep(100),
+
+    ?assertMatch([{get_devaddr_ranges, _Req}], rcv_loop()),
+
+    %% We keep both ranges for inspection
+    ?assertEqual(
+        {ok, [Range2, Range1]},
+        router_ics_devaddr_worker:get_devaddr_ranges()
+    ),
+
+    %% 72000008 - 7200000F range is not sent to the allocator
+    ?assertEqual(
+        {ok, lists:seq(0, 7)},
+        router_device_devaddr:get_devaddr_bases()
     ),
 
     ok.

--- a/test/router_ics_devaddr_worker_SUITE.erl
+++ b/test/router_ics_devaddr_worker_SUITE.erl
@@ -45,6 +45,7 @@ init_per_testcase(TestCase, Config) ->
         ics,
         #{
             devaddr_enabled => "true",
+            transport => http,
             host => "localhost",
             port => Port,
             route_id => "test_route_id"

--- a/test/router_ics_eui_worker_SUITE.erl
+++ b/test/router_ics_eui_worker_SUITE.erl
@@ -1,6 +1,5 @@
 -module(router_ics_eui_worker_SUITE).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include("../src/grpc/autogen/iot_config_pb.hrl").
 

--- a/test/router_test_ics_route_service.erl
+++ b/test/router_test_ics_route_service.erl
@@ -44,10 +44,10 @@ handle_info({devaddr_range, DevaddrRange, Last}, StreamState) ->
     lager:info("got devaddr_range ~p, eos: ~p", [DevaddrRange, Last]),
     grpcbox_stream:send(Last, DevaddrRange, StreamState);
 handle_info({devaddr_ranges, Ranges}, StreamState) ->
-    ct:print("got ~p devaddr ranges", [erlang:length(Ranges)]),
+    lager:info("got ~p devaddr ranges", [erlang:length(Ranges)]),
     lists:foreach(
         fun({Last, Range}) ->
-            ct:print("sending devaddr range: ~p at ~p", [Range, Last]),
+            lager:info("sending devaddr range: ~p at ~p", [Range, Last]),
             grpcbox_stream:send(Last, Range, StreamState)
         end,
         router_utils:enumerate_last(Ranges)
@@ -171,7 +171,7 @@ devaddr_range(DevaddrRange, Last) ->
 
 -spec devaddr_ranges(DevaddrRanges :: list(iot_config_pb:iot_config_devaddr_range_v1_pb())) -> ok.
 devaddr_ranges(DevaddrRanges) ->
-    ct:print("~p devaddr_ranges @ ~p", [
+    lager:info("~p devaddr_ranges @ ~p", [
         erlang:length(DevaddrRanges), erlang:whereis(?GET_DEVADDRS_STREAM)
     ]),
     case erlang:whereis(?GET_DEVADDRS_STREAM) of

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -205,17 +205,6 @@ init_per_testcase(TestCase, Config) ->
 
     ok = router_console_dc_tracker:refill(?CONSOLE_ORG_ID, 1, 100),
 
-    %% Chain = blockchain_worker:blockchain(),
-    %% ok = persistent_term:put(router_blockchain, Chain),
-
-    meck:new(router_blockchain, [passthrough]),
-    %% meck:expect(router_blockchain, calculate_dc_amount, fun(PayloadSize) ->
-    %%     blockchain_utils:do_calculate_dc_amount(PayloadSize, 24)
-    %% end),
-    %% meck:expect(router_blockchain, max_xor_filter_num, fun() -> 5 end),
-    %% meck:expect(router_blockchain, sc_version, fun() -> 2 end),
-    %% meck:expect(router_blockchain, max_open_sc, fun() -> 5 end),
-
     [
         {app_key, AppKey},
         {ets, Tab},
@@ -245,7 +234,6 @@ end_per_testcase(_TestCase, Config) ->
     Tab = proplists:get_value(ets, Config),
     ets:delete(Tab),
     meck:unload(router_device_devaddr),
-    meck:unload(router_blockchain),
     ok.
 
 start_swarm(BaseDir, Name, Port) ->


### PR DESCRIPTION
TODO: 
- [x] tell `router_device_devaddr` about devaddr ranges from config service
  - [x] convert start/end format to base/mask
- [x] how to switch over from chain routing
- [ ] don't route packets until we can get devaddr range from config service