### PR TITLE
eui vs xor

### DIFF
--- a/src/cli/router_cli_registry.erl
+++ b/src/cli/router_cli_registry.erl
@@ -11,4 +11,9 @@
 -export([register_cli/0]).
 
 register_cli() ->
-    clique:register(?CLI_MODULES).
+    Modules =
+        case router_xor_filter_worker:enabled() of
+            true -> ?CLI_MODULES;
+            false -> lists:delete(router_cli_xor_filter, ?CLI_MODULES)
+        end,
+    clique:register(Modules).

--- a/src/grpc/router_ics_devaddr_worker.erl
+++ b/src/grpc/router_ics_devaddr_worker.erl
@@ -63,7 +63,7 @@
 start_link(Args) ->
     case router_ics_utils:start_link_args(Args) of
         #{devaddr_enabled := "true"} = Map ->
-            case maps:get(route_id, Map) of
+            case maps:get(route_id, Map, undefined) of
                 undefined ->
                     lager:warning("~p enabled, but no route_id provided, ignoring", [?MODULE]),
                     ignore;

--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -63,7 +63,13 @@
 start_link(Args) ->
     case router_ics_utils:start_link_args(Args) of
         #{eui_enabled := "true"} = Map ->
-            gen_server:start_link({local, ?SERVER}, ?SERVER, Map, []);
+            case maps:get(route_id, Map) of
+                undefined ->
+                    lager:warning("~p enabled, but not route_id provided, ignoring", [?MODULE]),
+                    ignore;
+                _ ->
+                    gen_server:start_link({local, ?SERVER}, ?SERVER, Map, [])
+            end;
         _ ->
             lager:warning("~s ignored ~p", [?MODULE, Args]),
             ignore

--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -63,7 +63,7 @@
 start_link(Args) ->
     case router_ics_utils:start_link_args(Args) of
         #{eui_enabled := "true"} = Map ->
-            case maps:get(route_id, Map) of
+            case maps:get(route_id, Map, undefined) of
                 undefined ->
                     lager:warning("~p enabled, but not route_id provided, ignoring", [?MODULE]),
                     ignore;

--- a/src/router_sup.erl
+++ b/src/router_sup.erl
@@ -145,7 +145,7 @@ init([]) ->
             ?SUP(router_console_sup, []),
             ?SUP(router_decoder_sup, []),
             ?WORKER(router_device_devaddr, [#{}]),
-            ?WORKER(router_xor_filter_worker, [#{}]),
+            ?WORKER(router_xor_filter_worker, [#{ics_options => ICSOpts}]),
             ?WORKER(router_ics_devaddr_worker, [ICSOpts]),
             ?WORKER(router_ics_eui_worker, [ICSOpts]),
             ?WORKER(router_ics_skf_worker, [ICSOpts]),

--- a/src/router_xor_filter_worker.erl
+++ b/src/router_xor_filter_worker.erl
@@ -81,8 +81,14 @@
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
-start_link(Args) ->
-    gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []).
+start_link(#{ics_options := ICSOpts} = Args) ->
+    case maps:get(eui_enabled, ICSOpts, undefined) of
+        "true" ->
+            lager:info("config service EUI worker enabled, ignoring ~p", [?MODULE]),
+            ignore;
+        _ ->
+            gen_server:start_link({local, ?SERVER}, ?SERVER, Args, [])
+    end.
 
 -spec estimate_cost() ->
     noop

--- a/src/router_xor_filter_worker.erl
+++ b/src/router_xor_filter_worker.erl
@@ -26,7 +26,8 @@
 
 -export([
     deveui_appeui/1,
-    get_devices_deveui_app_eui/1
+    get_devices_deveui_app_eui/1,
+    enabled/0
 ]).
 
 -export([
@@ -1138,11 +1139,8 @@ schedule_check_filters(Timer) ->
 
 -spec enabled() -> boolean().
 enabled() ->
-    case application:get_env(router, router_xor_filter_worker, false) of
-        "true" -> true;
-        true -> true;
-        _ -> false
-    end.
+    router_utils:get_env_bool(router_xor_filter_worker, false) andalso
+        not router_blockchain:is_chain_dead().
 
 -spec default_timer() -> non_neg_integer().
 default_timer() ->

--- a/test/router_xor_filter_SUITE.erl
+++ b/test/router_xor_filter_SUITE.erl
@@ -24,7 +24,8 @@
     device_add_multiple_send_updates_to_console_test/1,
     device_add_unique_and_matching_send_updates_to_console_test/1,
     device_removed_send_updates_to_console_test/1,
-    estimate_cost_test/1
+    estimate_cost_test/1,
+    ignore_start_when_config_service_eui_enabled/1
 ]).
 
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
@@ -68,12 +69,28 @@ all() ->
         device_add_multiple_send_updates_to_console_test,
         device_add_unique_and_matching_send_updates_to_console_test,
         device_removed_send_updates_to_console_test,
-        estimate_cost_test
+        estimate_cost_test,
+        ignore_start_when_config_service_eui_enabled
     ].
 
 %%--------------------------------------------------------------------
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
+
+init_per_testcase(ignore_start_when_config_service_eui_enabled, Config) ->
+    ok = application:set_env(
+        router,
+        ics,
+        #{
+            eui_enabled => "true",
+            transport => "http",
+            host => "localhost",
+            port => 8085,
+            route_id => "test_route_id"
+        },
+        [{persistent, true}]
+    ),
+    test_utils:init_per_testcase(ignore_start_when_config_service_eui_enabled, Config);
 init_per_testcase(TestCase, Config0) ->
     application:set_env(router, router_xor_filter_worker, false),
     Config = test_utils:init_per_testcase(TestCase, Config0),
@@ -1383,6 +1400,10 @@ estimate_cost_test(Config) ->
 
     ?assert(meck:validate(blockchain_worker)),
     meck:unload(blockchain_worker),
+    ok.
+
+ignore_start_when_config_service_eui_enabled(_Config) ->
+    ?assertEqual(undefined, whereis(router_xor_filter_worker)),
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
- Require `route_id` for Devaddr and EUI workers to start.
- Disable xor filter worker when EUI worker is enabled.
- Remove xor filter cli when chain is dead.