### PR TITLE
allow for disabling of state channel worker

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -26,9 +26,13 @@ ROUTER_CONSOLE_SECRET=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Public facing endpoint to POST downlinks for devices
 ROUTER_CONSOLE_DOWNLINK_ENDPOINT=http://helium_console:4000
 
-# Turn on/off xor filter worker (anything else than true is off, disabled by default)
+# Turn on/off xor filter worker (anything other than true is off, disabled by default)
 # This allows to publish app eui / dev eui for join packets
 ROUTER_XOR_FILTER_WORKER=false
+
+# Turn on/off state channel worker (anything other than true is off, enabled by default)
+# This allows the opening/closing of state channels
+ROUTER_SC_WORKER=true
 
 # Max time to wait for uplinks in ms
 # Default: 200ms blocks when not set


### PR DESCRIPTION
You can manually disable the state channel worker by setting the env var `ROUTER_SC_WORKER` to `false`. The worker will disable itself when the chain is dead.