### PR TITLE
Streams can be closed in more than 1 way

### DIFF
--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -387,6 +387,7 @@ update_euis(List, State) ->
             ok = grpcbox_client:close_send(Stream),
             case grpcbox_client:recv_data(Stream) of
                 {ok, #iot_config_route_euis_res_v1_pb{}} -> ok;
+                stream_finished -> ok;
                 Reason -> {error, Reason}
             end
     end.

--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -351,6 +351,7 @@ update_skf(List, State) ->
             ok = grpcbox_client:close_send(Stream),
             case grpcbox_client:recv_data(Stream) of
                 {ok, #iot_config_session_key_filter_update_res_v1_pb{}} -> ok;
+                stream_finished -> ok;
                 Reason -> {error, Reason}
             end
     end.


### PR DESCRIPTION
they can return {ok, Data}, or just stream_finished.

These tests.
https://github.com/tsloughter/grpcbox/blob/37a7bd8e9abef187c67e9d04f7be967710cc6003/test/grpcbox_SUITE.erl#L373-L392

The way this unary handler accepts `stream_finished` as a success. https://github.com/tsloughter/grpcbox/blob/a5aa6e918a2ddbff40e8ebb3c12b1453fe953e03/src/grpcbox_client.erl#L92-L94

And these `stream_finished` not being wrapped in `{error, _}` tuples. https://github.com/tsloughter/grpcbox/blob/5ea123f2009b26acc6e730801f2b2de17bdfdda2/src/grpcbox_client_stream.erl#L103-L125