### PR TITLE
ics update timeouts

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -57,6 +57,7 @@
             route_id => "${ROUTER_ICS_ROUTE_ID}"
         }},
         {skf_max_timeout_attempt, 5},
+        {eui_max_timeout_attempt, 5},
         {frame_timeout, "${ROUTER_FRAME_TIMEOUT}"},
         {disco_frame_timeout, "${ROUTER_DISCO_FRAME_TIMEOUT}"},
         {router_http_channel_url_check, "${ROUTER_HTTP_CHANNEL_URL_CHECK}"},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -56,6 +56,7 @@
             devaddr_enabled => "${ROUTER_ICS_DEVADDR_ENABLED}",
             route_id => "${ROUTER_ICS_ROUTE_ID}"
         }},
+        {skf_max_timeout_attempt, 5},
         {frame_timeout, "${ROUTER_FRAME_TIMEOUT}"},
         {disco_frame_timeout, "${ROUTER_DISCO_FRAME_TIMEOUT}"},
         {router_http_channel_url_check, "${ROUTER_HTTP_CHANNEL_URL_CHECK}"},

--- a/config/test.config
+++ b/config/test.config
@@ -6,7 +6,8 @@
         {max_v8_context, 10},
         {router_http_channel_url_check, false},
         {router_xor_filter_worker, false},
-        {charge_when_no_offer, true}
+        {charge_when_no_offer, true},
+        {skf_max_timeout_attempt, 5}
     ]},
     {blockchain, [
         {port, 3615},

--- a/config/test.config
+++ b/config/test.config
@@ -7,7 +7,8 @@
         {router_http_channel_url_check, false},
         {router_xor_filter_worker, false},
         {charge_when_no_offer, true},
-        {skf_max_timeout_attempt, 5}
+        {skf_max_timeout_attempt, 5},
+        {eui_max_timeout_attempt, 5}
     ]},
     {blockchain, [
         {port, 3615},

--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -408,11 +408,16 @@ wait_for_stream_close({ok, _}, _Stream, _TimeoutAttempts, _MaxAttempts) ->
 wait_for_stream_close(stream_finished, _Stream, _TimeoutAttempts, _MaxAttempts) ->
     ok;
 wait_for_stream_close(init, Stream, TimeoutAttempts, MaxAttempts) ->
-    wait_for_stream_close(grpcbox_client:recv_data(Stream), Stream, TimeoutAttempts, MaxAttempts);
+    wait_for_stream_close(
+        grpcbox_client:recv_data(Stream, timer:seconds(2)),
+        Stream,
+        TimeoutAttempts,
+        MaxAttempts
+    );
 wait_for_stream_close(timeout, Stream, TimeoutAttempts, MaxAttempts) ->
     timer:sleep(250),
     wait_for_stream_close(
-        grpcbox_client:recv_data(Stream),
+        grpcbox_client:recv_data(Stream, timer:seconds(2)),
         Stream,
         TimeoutAttempts + 1,
         MaxAttempts

--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -385,12 +385,38 @@ update_euis(List, State) ->
                 List
             ),
             ok = grpcbox_client:close_send(Stream),
-            case grpcbox_client:recv_data(Stream) of
-                {ok, #iot_config_route_euis_res_v1_pb{}} -> ok;
-                stream_finished -> ok;
-                Reason -> {error, Reason}
-            end
+            wait_for_stream_close(
+                init,
+                Stream,
+                0,
+                router_utils:get_env_int(eui_max_timeout_attempt, 5)
+            )
     end.
+
+-spec wait_for_stream_close(
+    Result :: init | stream_finished | timeout | {ok, any()} | {error, any()},
+    Stream :: map(),
+    CurrentAttempts :: non_neg_integer(),
+    MaxAttempts :: non_neg_integer()
+) -> ok | {error, any()}.
+wait_for_stream_close(_, _, MaxAttempts, MaxAttempts) ->
+    {error, {max_timeouts_reached, MaxAttempts}};
+wait_for_stream_close({error, _} = Err, _Stream, _TimeoutAttempts, _MaxAttempts) ->
+    Err;
+wait_for_stream_close({ok, _}, _Stream, _TimeoutAttempts, _MaxAttempts) ->
+    ok;
+wait_for_stream_close(stream_finished, _Stream, _TimeoutAttempts, _MaxAttempts) ->
+    ok;
+wait_for_stream_close(init, Stream, TimeoutAttempts, MaxAttempts) ->
+    wait_for_stream_close(grpcbox_client:recv_data(Stream), Stream, TimeoutAttempts, MaxAttempts);
+wait_for_stream_close(timeout, Stream, TimeoutAttempts, MaxAttempts) ->
+    timer:sleep(250),
+    wait_for_stream_close(
+        grpcbox_client:recv_data(Stream),
+        Stream,
+        TimeoutAttempts + 1,
+        MaxAttempts
+    ).
 
 -spec update_euis(
     Action :: add | remove,

--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -364,6 +364,7 @@ update_skf(List, State) ->
     MaxAttempts :: non_neg_integer()
 ) -> ok | {error, any()}.
 wait_for_stream_close(_, _, MaxAttempts, MaxAttempts) ->
+    lager:warning("stream did not close within ~p attempts", [MaxAttempts]),
     {error, {max_timeouts_reached, MaxAttempts}};
 wait_for_stream_close({error, _} = Err, _Stream, _TimeoutAttempts, _MaxAttempts) ->
     Err;
@@ -379,6 +380,7 @@ wait_for_stream_close(init, Stream, TimeoutAttempts, MaxAttempts) ->
         MaxAttempts
     );
 wait_for_stream_close(timeout, Stream, TimeoutAttempts, MaxAttempts) ->
+    lager:warning("waiting for stream to close, attempt ~p/~p", [TimeoutAttempts, MaxAttempts]),
     timer:sleep(250),
     wait_for_stream_close(
         grpcbox_client:recv_data(Stream, timer:seconds(2)),

--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -372,11 +372,16 @@ wait_for_stream_close({ok, _}, _Stream, _TimeoutAttempts, _MaxAttempts) ->
 wait_for_stream_close(stream_finished, _Stream, _TimeoutAttempts, _MaxAttempts) ->
     ok;
 wait_for_stream_close(init, Stream, TimeoutAttempts, MaxAttempts) ->
-    wait_for_stream_close(grpcbox_client:recv_data(Stream), Stream, TimeoutAttempts, MaxAttempts);
+    wait_for_stream_close(
+        grpcbox_client:recv_data(Stream, timer:seconds(2)),
+        Stream,
+        TimeoutAttempts,
+        MaxAttempts
+    );
 wait_for_stream_close(timeout, Stream, TimeoutAttempts, MaxAttempts) ->
     timer:sleep(250),
     wait_for_stream_close(
-        grpcbox_client:recv_data(Stream),
+        grpcbox_client:recv_data(Stream, timer:seconds(2)),
         Stream,
         TimeoutAttempts + 1,
         MaxAttempts

--- a/test/router_ics_eui_worker_SUITE.erl
+++ b/test/router_ics_eui_worker_SUITE.erl
@@ -202,6 +202,15 @@ reconcile_test(_Config) ->
     meck:new(router_console_api, [passthrough]),
     meck:new(router_device_cache, [passthrough]),
 
+    %% Simulate server side processsing by telling the test service to wait
+    %% before closing it's side of the stream after the client has signaled it
+    %% is done sending updates.
+
+    %% NOTE: Settting this value over the number of TimeoutAttempt will wait for
+    %% a tream close will cause this test to fail, it will look like the worker
+    %% has tried to reconcile again.
+    ok = application:set_env(router, test_eui_update_eos_timeout, timer:seconds(2)),
+
     RouteID = ?ROUTE_ID,
     ID1 = router_utils:uuid_v4(),
     Device1 = router_device:update(

--- a/test/router_ics_skf_worker_SUITE.erl
+++ b/test/router_ics_skf_worker_SUITE.erl
@@ -266,6 +266,15 @@ main_test(Config) ->
 reconcile_test(_Config) ->
     meck:new(router_device_cache, [passthrough]),
 
+    %% Simulate server side processsing by telling the test service to wait
+    %% before closing it's side of the stream after the client has signaled it
+    %% is done sending updates.
+
+    %% NOTE: Settting this value over the number of TimeoutAttempt will wait for
+    %% a tream close will cause this test to fail, it will look like the worker
+    %% has tried to reconcile again.
+    ok = application:set_env(router, test_skf_update_eos_timeout, timer:seconds(2)),
+
     %% creating couple devices for testing
     Devices0 = lists:map(
         fun(X) ->

--- a/test/router_test_ics_route_service.erl
+++ b/test/router_test_ics_route_service.erl
@@ -86,7 +86,10 @@ get_euis(Req, StreamState) ->
     end.
 
 update_euis(eos, StreamState) ->
-    lager:info("got EOS"),
+    Timeout = application:get_env(router, test_eui_update_eos_timeout, 0),
+    lager:info("got EOS, waiting ~wms to return with close", [Timeout]),
+    timer:sleep(Timeout),
+    lager:info("closing server side of eui update stream"),
     {ok, #iot_config_route_euis_res_v1_pb{}, StreamState};
 update_euis(Req, _StreamState) ->
     case verify_update_euis_req(Req) of

--- a/test/router_test_ics_skf_service.erl
+++ b/test/router_test_ics_skf_service.erl
@@ -53,7 +53,7 @@ update(eos, StreamState) ->
     Timeout = application:get_env(router, test_skf_update_eos_timeout, 0),
     lager:info("got EOS, waiting ~wms to return with close", [Timeout]),
     timer:sleep(Timeout),
-    lager:info("closing server side of update stream"),
+    lager:info("closing server side of skf update stream"),
     {ok, #iot_config_route_euis_res_v1_pb{}, StreamState};
 update(Req, StreamState) ->
     case verify_skf_update_req(Req) of

--- a/test/router_test_ics_skf_service.erl
+++ b/test/router_test_ics_skf_service.erl
@@ -50,7 +50,10 @@ get(_Ctx, _Msg) ->
     {grpc_error, {12, <<"UNIMPLEMENTED">>}}.
 
 update(eos, StreamState) ->
-    lager:info("got EOS"),
+    Timeout = application:get_env(router, test_skf_update_eos_timeout, 0),
+    lager:info("got EOS, waiting ~wms to return with close", [Timeout]),
+    timer:sleep(Timeout),
+    lager:info("closing server side of update stream"),
     {ok, #iot_config_route_euis_res_v1_pb{}, StreamState};
 update(Req, StreamState) ->
     case verify_skf_update_req(Req) of


### PR DESCRIPTION
Add a retry mechanism when receiving a timeout for a stream close on the eui and skf workers.