### PR TITLE
add a configurable delay while sending large batches of updates

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -56,8 +56,8 @@
             devaddr_enabled => "${ROUTER_ICS_DEVADDR_ENABLED}",
             route_id => "${ROUTER_ICS_ROUTE_ID}"
         }},
-        {skf_max_timeout_attempt, 5},
-        {eui_max_timeout_attempt, 5},
+        {config_service_max_timeout_attempt, 5},
+        {config_service_batch_sleep_ms, 500},
         {frame_timeout, "${ROUTER_FRAME_TIMEOUT}"},
         {disco_frame_timeout, "${ROUTER_DISCO_FRAME_TIMEOUT}"},
         {router_http_channel_url_check, "${ROUTER_HTTP_CHANNEL_URL_CHECK}"},

--- a/config/test.config
+++ b/config/test.config
@@ -7,8 +7,7 @@
         {router_http_channel_url_check, false},
         {router_xor_filter_worker, false},
         {charge_when_no_offer, true},
-        {skf_max_timeout_attempt, 5},
-        {eui_max_timeout_attempt, 5}
+        {config_service_max_timeout_attempt, 5}
     ]},
     {blockchain, [
         {port, 3615},

--- a/src/grpc/router_ics_eui_worker.erl
+++ b/src/grpc/router_ics_eui_worker.erl
@@ -386,7 +386,7 @@ update_euis(List, State) ->
             ),
 
             ok = grpcbox_client:close_send(Stream),
-            lager:info("done sending eui update ltimeout_retry: ~p]", [MaxAttempt]),
+            lager:info("done sending eui updates [timeout_retry: ~p]", [MaxAttempt]),
             wait_for_stream_close(init, Stream, 0, MaxAttempt)
     end.
 

--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -330,6 +330,9 @@ maybe_update_skf(List0, State) ->
 update_skf([], _State) ->
     ok;
 update_skf(List, State) ->
+    BatchSleep = router_utils:get_env_int(config_service_batch_sleep_ms, 500),
+    MaxAttempt = router_utils:get_env_int(config_service_max_timeout_attempt, 5),
+
     case
         helium_iot_config_session_key_filter_client:update(#{
             channel => router_ics_utils:channel()
@@ -338,25 +341,18 @@ update_skf(List, State) ->
         {error, _} = Error ->
             Error;
         {ok, Stream} ->
-            lists:foreach(
-                fun({Action, SKFs}) ->
-                    lists:foreach(
-                        fun(SKF) ->
-                            lager:info("~p ~p", [Action, SKF]),
-                            ok = update_skf(Action, SKF, Stream, State)
-                        end,
-                        SKFs
-                    )
+            router_ics_utils:batch_update(
+                fun(Action, SKF) ->
+                    lager:info("~p ~p", [Action, SKF]),
+                    ok = update_skf(Action, SKF, Stream, State)
                 end,
-                List
+                List,
+                BatchSleep
             ),
+
             ok = grpcbox_client:close_send(Stream),
-            wait_for_stream_close(
-                init,
-                Stream,
-                0,
-                router_utils:get_env_int(skf_max_timeout_attempt, 5)
-            )
+            lager:info("done sending skf update [timeout_retry: ~p]", [MaxAttempt]),
+            wait_for_stream_close(init, Stream, 0, MaxAttempt)
     end.
 
 -spec wait_for_stream_close(

--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -351,7 +351,7 @@ update_skf(List, State) ->
             ),
 
             ok = grpcbox_client:close_send(Stream),
-            lager:info("done sending skf update [timeout_retry: ~p]", [MaxAttempt]),
+            lager:info("done sending skf updates [timeout_retry: ~p]", [MaxAttempt]),
             wait_for_stream_close(init, Stream, 0, MaxAttempt)
     end.
 

--- a/src/grpc/router_ics_utils.erl
+++ b/src/grpc/router_ics_utils.erl
@@ -84,9 +84,40 @@ batch_update(Fun, List, BatchSleep) ->
                     ok = Fun(Action, El),
                     Idx + 1
                 end,
-                0,
+                1,
                 Els
             )
         end,
         List
     ).
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+batch_update_test() ->
+    Ok = fun(_, _) -> ok end,
+
+    %% warmup
+    {_, _} = timer:tc(?MODULE, batch_update, [Ok, [{add, lists:seq(1, 500)}], timer:seconds(0)]),
+    {_, _} = timer:tc(?MODULE, batch_update, [Ok, [{add, lists:seq(1, 500)}], timer:seconds(5)]),
+
+    {Time0, _} = timer:tc(?MODULE, batch_update, [Ok, [{add, lists:seq(1, 2500)}], 0]),
+    {Time1, _} = timer:tc(?MODULE, batch_update, [Ok, [{add, lists:seq(1, 2500)}], 50]),
+    {Time2, _} = timer:tc(?MODULE, batch_update, [Ok, [{add, lists:seq(1, 2500)}], 100]),
+    {Time3, _} = timer:tc(?MODULE, batch_update, [Ok, [{add, lists:seq(1, 2500)}], 150]),
+    %% ct:print("~p < ~p < ~p < ~p", [
+    %%     erlang:convert_time_unit(Time0, microsecond, millisecond),
+    %%     erlang:convert_time_unit(Time1, microsecond, millisecond),
+    %%     erlang:convert_time_unit(Time2, microsecond, millisecond),
+    %%     erlang:convert_time_unit(Time3, microsecond, millisecond)
+    %% ]),
+    ?assert(Time0 < Time1),
+    ?assert(Time1 < Time2),
+    ?assert(Time2 < Time3),
+
+    ok.
+
+-endif.


### PR DESCRIPTION
If too many items are sent to the config service, it will get stuck reading everything from the network before it will continue doing any db operations, this can be very slow (think minutes). If we added a few strategic pauses to our streaming up of items, the config service can keep up and hopefully not fall behind, making the request seem to take only as long as it takes to send everything up.