### PR TITLE
remove skf from config service as creds are rolled

### DIFF
--- a/src/grpc/router_ics_skf_worker.erl
+++ b/src/grpc/router_ics_skf_worker.erl
@@ -281,12 +281,8 @@ handle_cast(
         Updates0
     ),
 
-    case send_update_request(RouteID, Updates1) of
-        {ok, Resp} ->
-            lager:info("updating skf good success: ~p", [Resp]);
-        {error, Err} ->
-            lager:error("updating skf bad failure: ~p", [Err])
-    end,
+    %% logging is already done in send_update_request/2
+    _ =  send_update_request(RouteID, Updates1),
     {noreply, State};
 handle_cast(_Msg, State) ->
     lager:warning("rcvd unknown cast msg: ~p", [_Msg]),


### PR DESCRIPTION
We keep the latest 25 DevAddrs and Keys for a device.
If joining takes more than that many attempts, by the time we get a valid first uplink, we may not be able to recreate all the Devaddr,NwkKey pairs that were sent to the config service.

As we roll through the credential limit, we remove pairs that are about to get thrown away.