### PR TITLE
expose Devaddr Prefix as env setting

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -60,4 +60,8 @@ ROUTER_DEVADDR_ALLOCATE_RESOLUTION=3
 ROUTER_METRICS_PORT=3000
 
 # The first 7 bits of a DevAddr as an integer. (default: 72 :: $H)
+# __DISCLAIMER__:
+#  This setting _only_ works for NetIDs of Type-0.
+#  The integer represents the first 7-bits of a DevAddr. NOT the Network ID.
+#  Change at your own discretion, this may lead to instability in assigning DevAddrs to devices.
 ROUTER_DEVADDR_PREFIX=72

--- a/.env-template
+++ b/.env-template
@@ -58,3 +58,6 @@ ROUTER_DEVADDR_ALLOCATE_RESOLUTION=3
 
 # Set http port for Prometheus handler to come scrape metrics (Default to port 3000)
 ROUTER_METRICS_PORT=3000
+
+# The first 7 bits of a DevAddr as an integer. (default: 72 :: $H)
+ROUTER_DEVADDR_PREFIX=72

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -33,6 +33,7 @@
         {sc_hook_close_submit, router_sc_worker}
     ]},
     {router, [
+        {devaddr_prefix, "${ROUTER_DEVADDR_PREFIX}"},
         {is_chain_dead, "${ROUTER_IS_CHAIN_DEAD}"},
         {grpc_port, ${GRPC_PORT:-8080}},
         {max_v8_context, 1000},

--- a/config/test.config
+++ b/config/test.config
@@ -2,6 +2,7 @@
 [
     {router, [
         {oui, 1},
+        {devaddr_prefix, "72"},
         {metrics_port, 3001},
         {max_v8_context, 10},
         {router_http_channel_url_check, false},

--- a/src/cli/router_cli_migration.erl
+++ b/src/cli/router_cli_migration.erl
@@ -248,7 +248,7 @@ get_ouis() ->
                     [] -> Owner;
                     [Router1 | _] -> Router1
                 end,
-            Prefix = $H,
+            Prefix = router_utils:get_env_int(devaddr_prefix, $H),
             DevAddrRanges = lists:map(
                 fun(<<Base:25, Mask:23>> = _Subnet) ->
                     Size = blockchain_ledger_routing_v1:subnet_mask_to_size(Mask),
@@ -341,7 +341,7 @@ devaddr_ranges(RoutingEntry) ->
     lists:foldl(
         fun(<<Base:25, Mask:23>>, {Acc, _}) ->
             Size = blockchain_ledger_routing_v1:subnet_mask_to_size(Mask),
-            Prefix = $H,
+            Prefix = router_utils:get_env_int(devaddr_prefix, $H),
             Min = lorawan_utils:reverse(<<Base:25/integer-unsigned-little, Prefix:7/integer>>),
             Max = lorawan_utils:reverse(<<
                 (Base + Size - 1):25/integer-unsigned-little, Prefix:7/integer

--- a/src/device/router_device_devaddr.erl
+++ b/src/device/router_device_devaddr.erl
@@ -174,7 +174,7 @@ handle_call(
     CurrentIndex = maps:get(Parent, Keys, 0),
     DevaddrBase = lists:nth(CurrentIndex + 1, Numbers),
     NextIndex = (CurrentIndex + 1) rem length(Numbers),
-    DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+    DevAddrPrefix = router_utils:get_env_int(devaddr_prefix, $H),
 
     Reply = {ok, <<DevaddrBase:25/integer-unsigned-little, DevAddrPrefix:7/integer>>},
 
@@ -348,7 +348,7 @@ get_devaddrs(#state{route_id = RouteID}) ->
 
 -spec devaddr_num_to_base_num(non_neg_integer()) -> non_neg_integer().
 devaddr_num_to_base_num(DevaddrNum) ->
-    Prefix = application:get_env(blockchain, devaddr_prefix, $H),
+    Prefix = router_utils:get_env_int(devaddr_prefix, $H),
     <<Base:25/integer-unsigned-little, Prefix:7/integer>> = lorawan_utils:reverse(
         binary:encode_unsigned(DevaddrNum)
     ),

--- a/test/router_device_devaddr_SUITE.erl
+++ b/test/router_device_devaddr_SUITE.erl
@@ -99,7 +99,7 @@ allocate(Config) ->
     ),
     ?assertEqual(16, erlang:length(DevAddrs)),
 
-    DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+    DevAddrPrefix = router_utils:get_env_int(devaddr_prefix, $H),
     Expected = [
         <<(I - 1):25/integer-unsigned-little, DevAddrPrefix:7/integer>>
      || I <- lists:seq(1, 8)

--- a/test/router_grpc_SUITE.erl
+++ b/test/router_grpc_SUITE.erl
@@ -285,7 +285,8 @@ packet_from_known_device_no_downlink_gateway_test(Config) ->
     {ok, Device} = router_device:get_by_id(DB, CF, WorkerID),
 
     %% create an unconfirmed uplink
-    DevAddr = <<33554431:25/integer-unsigned-little, $H:7/integer>>,
+    Prefix = router_utils:get_env_int(devaddr_prefix, $H),
+    DevAddr = <<33554431:25/integer-unsigned-little, Prefix:7/integer>>,
     DataPacket1 = #packet_router_packet_up_v1_pb{
         payload = test_utils:frame_payload(
             ?UNCONFIRMED_UP,
@@ -376,7 +377,8 @@ join_packet(PubKeyBin, SigFun, AppKey, DevNonce, RSSI) ->
     #blockchain_state_channel_message_v1_pb{msg = {packet, SignedSCPacket}}.
 
 data_packet_map(MType, Fcnt, PubKeyBin, Device, SigFun, Options) ->
-    DevAddr0 = <<33554431:25/integer-unsigned-little, $H:7/integer>>,
+    Prefix = router_utils:get_env_int(devaddr_prefix, $H),
+    DevAddr0 = <<33554431:25/integer-unsigned-little, Prefix:7/integer>>,
     <<DevAddr:32/integer-unsigned-little>> = DevAddr0,
     P = #packet_pb{
         oui = 0,

--- a/test/router_lorawan_SUITE.erl
+++ b/test/router_lorawan_SUITE.erl
@@ -74,7 +74,7 @@ init_per_testcase(TestCase, Config) ->
     _ = persistent_term:erase(router_blockchain),
     meck:new(router_device_devaddr, [passthrough]),
     meck:expect(router_device_devaddr, allocate, fun(_, _) ->
-        DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+        DevAddrPrefix = router_utils:get_env_int(devaddr_prefix, $H),
         {ok, <<33554431:25/integer-unsigned-little, DevAddrPrefix:7/integer>>}
     end),
     Region = proplists:get_value(region, Config),

--- a/test/router_lorawan_handler_test.erl
+++ b/test/router_lorawan_handler_test.erl
@@ -123,7 +123,8 @@ handle_info(
     #{<<"rxpk">> := [JSON]} = jsx:decode(JSONBin, [return_maps]),
     lager:info("got packet ~p", [JSON]),
     State#state.pid ! rx,
-    <<DevNum:32/integer-unsigned-little>> = <<33554431:25/integer-unsigned-little, $H:7/integer>>,
+    Prefix = router_utils:get_env_int(devaddr_prefix, $H),
+    <<DevNum:32/integer-unsigned-little>> = <<33554431:25/integer-unsigned-little, Prefix:7/integer>>,
     HeliumPacket = #packet_pb{
         type = lorawan,
         payload = base64:decode(maps:get(<<"data">>, JSON)),

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -62,7 +62,7 @@ init_per_testcase(TestCase, Config) ->
     _ = persistent_term:erase(router_blockchain),
     meck:new(router_device_devaddr, [passthrough]),
     meck:expect(router_device_devaddr, allocate, fun(_, _) ->
-        DevAddrPrefix = application:get_env(blockchain, devaddr_prefix, $H),
+        DevAddrPrefix = router_utils:get_env_int(devaddr_prefix, $H),
         {ok, <<33554431:25/integer-unsigned-little, DevAddrPrefix:7/integer>>}
     end),
 

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -972,7 +972,8 @@ frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt) ->
     frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, #{}).
 
 frame_packet(MType, PubKeyBin, NwkSessionKey, AppSessionKey, FCnt, Options) ->
-    DevAddr = maps:get(devaddr, Options, <<33554431:25/integer-unsigned-little, $H:7/integer>>),
+    Prefix = router_utils:get_env_int(devaddr_prefix, $H),
+    DevAddr = maps:get(devaddr, Options, <<33554431:25/integer-unsigned-little, Prefix:7/integer>>),
     Payload1 = frame_payload(MType, DevAddr, NwkSessionKey, AppSessionKey, FCnt, Options),
     <<DevNum:32/integer-unsigned-little>> = DevAddr,
     Routing = blockchain_helium_packet_v1:make_routing_info({devaddr, DevNum}),


### PR DESCRIPTION
:warning: This will __only__ work with Devaddrs of a Type-0 NetID.