### PR TITLE
Stop assuming unfetchable orgs balance

### DIFF
--- a/src/apis/router_console_api.erl
+++ b/src/apis/router_console_api.erl
@@ -1044,7 +1044,7 @@ get_org_(OrgID) ->
             lager:debug("org ~p not found", [OrgID]),
             End = erlang:system_time(millisecond),
             ok = router_metrics:console_api_observe(get_org, not_found, End - Start),
-            {error, not_found};
+            {error, org_not_found};
         _Other ->
             End = erlang:system_time(millisecond),
             ok = router_metrics:console_api_observe(get_org, error, End - Start),

--- a/src/device/router_device_routing.erl
+++ b/src/device/router_device_routing.erl
@@ -781,7 +781,7 @@ check_device_is_active(Device, PubKeyBin) ->
 ) -> ok | {error, ?DEVICE_NO_DC}.
 check_device_balance(PayloadSize, Device, PubKeyBin) ->
     try router_console_dc_tracker:has_enough_dc(Device, PayloadSize) of
-        {error, _Reason} ->
+        {error, {not_enough_dc, _, _}} ->
             ok = router_utils:event_uplink_dropped_not_enough_dc(
                 erlang:system_time(millisecond),
                 router_device:fcnt(Device),
@@ -789,6 +789,8 @@ check_device_balance(PayloadSize, Device, PubKeyBin) ->
                 PubKeyBin
             ),
             {error, ?DEVICE_NO_DC};
+        {error, _} = Err ->
+            Err;
         {ok, _OrgID, _Balance, _Nonce} ->
             ok
     catch


### PR DESCRIPTION
propogate errors from the console api all the way up in the case where a specific org balance cannot be fetched. Avoiding the case where we assume the balance is zero, and the next packet that comes through within the cache time will see that value of zero and force the depletion on Console through another event.